### PR TITLE
Refactor swank_process: inline callbacks and remove unused code

### DIFF
--- a/opt/swank_process.c
+++ b/opt/swank_process.c
@@ -1,4 +1,5 @@
 #include "swank_process.h"
+#include "swank_session.h" // For swank_session_on_message_internal
 // #include "process.h" // For global process functions - Will be merged
 #include "preferences.h"  // For global preferences functions
 #include "syscalls.h"     // For sys_read, sys_write
@@ -21,10 +22,8 @@ static gint g_process_in_fd = -1;  // Parent's write end to child's stdin
 static gint g_process_out_fd = -1; // Parent's read end from child's stdout
 static gint g_process_err_fd = -1; // Parent's read end from child's stderr
 
-static GlobalProcessCallback g_process_out_cb = NULL;
-static gpointer g_process_out_user_data = NULL;
-static GlobalProcessCallback g_process_err_cb = NULL;
-static gpointer g_process_err_user_data = NULL;
+// Removed g_process_out_cb, g_process_out_user_data, g_process_err_cb, g_process_err_user_data
+// Callbacks are now hardcoded.
 
 static GThread *g_process_out_thread = NULL;
 static GThread *g_process_err_thread = NULL;
@@ -37,13 +36,10 @@ static gpointer stdout_thread_global(gpointer /*data*/) {
   char buf[256];
   ssize_t n = 0;
   while (g_process_out_fd >= 0 && (n = sys_read(g_process_out_fd, buf, sizeof(buf))) > 0) {
-    if (g_process_out_cb) {
-      GString *s = g_string_new_len(buf, n);
-      g_process_out_cb(s, g_process_out_user_data);
-      // The original ProcessCallback implied data was transient and freed the GString after the call.
-      // We follow that pattern here.
-      g_string_free(s, TRUE);
-    }
+    // Directly call on_lisp_stdout, assuming it's the intended hardcoded callback
+    GString *s = g_string_new_len(buf, n);
+    on_lisp_stdout(s, NULL); // g_process_out_user_data was NULL for this path
+    g_string_free(s, TRUE);
   }
   g_debug("process_global: stdout_thread_global exiting, n=%zd, errno=%d", n, n == -1 ? errno : 0);
   return NULL;
@@ -55,11 +51,10 @@ static gpointer stderr_thread_global(gpointer /*data*/) {
   char buf[256];
   ssize_t n = 0;
   while (g_process_err_fd >=0 && (n = sys_read(g_process_err_fd, buf, sizeof(buf))) > 0) {
-    if (g_process_err_cb) {
-      GString *s = g_string_new_len(buf, n);
-      g_process_err_cb(s, g_process_err_user_data);
-      g_string_free(s, TRUE);
-    }
+    // Directly call on_lisp_stderr, assuming it's the intended hardcoded callback
+    GString *s = g_string_new_len(buf, n);
+    on_lisp_stderr(s, NULL); // g_process_err_user_data was NULL for this path
+    g_string_free(s, TRUE);
   }
   g_debug("process_global: stderr_thread_global exiting, n=%zd, errno=%d", n, n == -1 ? errno : 0);
   return NULL;
@@ -77,7 +72,7 @@ static void child_setup_global(gpointer /*user_data*/) {
 }
 
 // Initialize global process state from argv
-void process_init_globals_from_argv(const gchar *const *argv) {
+static void process_init_globals_from_argv(const gchar *const *argv) {
   g_debug("process_init_globals_from_argv: cmd=%s", argv && argv[0] ? argv[0] : "(null)");
   if (g_process_started) {
     g_warning("process_init_globals_from_argv: Process already initialized or started. Cleaning up old one.");
@@ -91,10 +86,10 @@ void process_init_globals_from_argv(const gchar *const *argv) {
   g_process_in_fd = -1;
   g_process_out_fd = -1;
   g_process_err_fd = -1;
-  g_process_out_cb = NULL;
-  g_process_out_user_data = NULL;
-  g_process_err_cb = NULL;
-  g_process_err_user_data = NULL;
+  // g_process_out_cb = NULL; // Removed
+  // g_process_out_user_data = NULL; // Removed
+  // g_process_err_cb = NULL; // Removed
+  // g_process_err_user_data = NULL; // Removed
   g_process_out_thread = NULL;
   g_process_err_thread = NULL;
   g_process_started = FALSE; // Set to TRUE in _start()
@@ -112,23 +107,8 @@ void process_init_globals(const gchar *cmd) {
   process_init_globals_from_argv(argv);
 }
 
-void process_global_set_stdout_cb(GlobalProcessCallback cb, gpointer user_data) {
-  g_debug("process_global_set_stdout_cb");
-  g_process_out_cb = cb;
-  g_process_out_user_data = user_data;
-  if (cb && g_process_started && !g_process_out_thread && g_process_out_fd >=0) {
-    g_process_out_thread = g_thread_new("process-stdout", stdout_thread_global, NULL);
-  }
-}
-
-void process_global_set_stderr_cb(GlobalProcessCallback cb, gpointer user_data) {
-  g_debug("process_global_set_stderr_cb");
-  g_process_err_cb = cb;
-  g_process_err_user_data = user_data;
-  if (cb && g_process_started && !g_process_err_thread && g_process_err_fd >=0) {
-    g_process_err_thread = g_thread_new("process-stderr", stderr_thread_global, NULL);
-  }
-}
+// Removed process_global_set_stdout_cb as callback is hardcoded
+// Removed process_global_set_stderr_cb as callback is hardcoded
 
 void process_global_start() {
   g_debug("process_global_start");
@@ -244,10 +224,10 @@ void process_cleanup_globals() {
   g_process_argv = NULL;
 
   g_process_started = FALSE;
-  g_process_out_cb = NULL;
-  g_process_err_cb = NULL;
-  g_process_out_user_data = NULL;
-  g_process_err_user_data = NULL;
+  // g_process_out_cb = NULL; // Removed
+  // g_process_err_cb = NULL; // Removed
+  // g_process_out_user_data = NULL; // Removed
+  // g_process_err_user_data = NULL; // Removed
 
   g_debug("process_cleanup_globals: Cleanup complete.");
 }
@@ -270,8 +250,8 @@ static GString *g_swank_incoming_data_buffer = NULL; // Buffer for data coming d
 static gsize    g_swank_incoming_consumed = 0;
 static GMutex   g_swank_incoming_mutex;   // To protect g_swank_incoming_data_buffer and g_swank_incoming_consumed
 
-static GlobalSwankProcessMessageCallback g_swank_message_cb = NULL;
-static gpointer g_swank_message_cb_data = NULL;
+// Removed g_swank_message_cb, g_swank_message_cb_data
+// Callback is now hardcoded to swank_session_on_message_internal
 
 static gint    g_swank_port_number = 4005; // Default, will be updated from global preferences
 static GThread *g_swank_reader_thread = NULL;
@@ -307,16 +287,16 @@ void swank_process_init_globals() {
 
     g_swank_fd = -1;
     g_swank_connection = NULL;
-    g_swank_message_cb = NULL;
-    g_swank_message_cb_data = NULL;
+    // g_swank_message_cb = NULL; // Removed
+    // g_swank_message_cb_data = NULL; // Removed
     g_swank_reader_thread = NULL;
 
     // Get Swank port from global preferences
     g_swank_port_number = 4005;
 
-    // Set up callbacks for the underlying Lisp process output
-    process_global_set_stdout_cb(on_lisp_stdout, NULL);
-    process_global_set_stderr_cb(on_lisp_stderr, NULL);
+    // Callbacks on_lisp_stdout and on_lisp_stderr are now directly called
+    // by their respective threads (stdout_thread_global, stderr_thread_global).
+    // Thus, no need to set them via process_global_set_stdout_cb here.
 
     g_swank_process_started = FALSE; // Will be set to TRUE in _global_start
     g_debug("swank_process_init_globals: complete. Port: %d", g_swank_port_number);
@@ -351,8 +331,8 @@ static gpointer swank_reader_thread_global(gpointer /*data*/) {
 
                             g_swank_incoming_consumed += (6 + msg_len);
 
-                            // Dispatch the message
-                            g_swank_message_cb(actual_msg, g_swank_message_cb_data);
+                            // Dispatch the message by directly calling swank_session_on_message_internal
+                            swank_session_on_message_internal(actual_msg, NULL); // g_swank_message_cb_data was NULL
                             // The original RealSwankProcess freed the GString after the callback, so we follow that.
                             g_string_free(actual_msg, TRUE);
 
@@ -561,32 +541,9 @@ void swank_process_global_send(const GString *payload) {
     g_debug("swank_process_global_send: Message sent successfully.");
 }
 
-void swank_process_global_set_message_cb(GlobalSwankProcessMessageCallback cb, gpointer user_data) {
-    g_debug("swank_process_global_set_message_cb");
-    g_mutex_lock(&g_swank_incoming_mutex);
-    g_swank_message_cb = cb;
-    g_swank_message_cb_data = user_data;
-    g_mutex_unlock(&g_swank_incoming_mutex);
-}
+// Removed swank_process_global_set_message_cb as callback is hardcoded
 
-void swank_process_global_set_socket_fd(int fd) {
-    g_debug("swank_process_global_set_socket_fd: Setting Swank FD to %d", fd);
-    if (g_swank_fd >= 0 && g_swank_fd != fd) { // If there's an existing valid FD
-        g_warning("swank_process_global_set_socket_fd: Closing existing Swank FD %d", g_swank_fd);
-        close(g_swank_fd); // Close the old one
-        if (g_swank_connection) {
-             g_object_unref(g_swank_connection); // Release connection if we manage it
-             g_swank_connection = NULL;
-        }
-    }
-    g_swank_fd = fd;
-    // If a reader thread was running on the old FD, it needs to be stopped and restarted for the new FD.
-    // This function is a bit risky if not managed carefully with the reader thread.
-    if (g_swank_reader_thread) {
-        g_debug("swank_process_global_set_socket_fd: Existing reader thread found. It might need manual restart.");
-        // For simplicity, current cleanup/init handles restarting reader thread if needed.
-    }
-}
+// Removed unused function swank_process_global_set_socket_fd
 
 void swank_process_cleanup_globals() {
     g_debug("swank_process_cleanup_globals: Starting cleanup.");
@@ -628,8 +585,8 @@ void swank_process_cleanup_globals() {
     g_cond_clear(&g_swank_out_cond);
     g_mutex_clear(&g_swank_incoming_mutex);
 
-    g_swank_message_cb = NULL;
-    g_swank_message_cb_data = NULL;
+    // g_swank_message_cb = NULL; // Removed
+    // g_swank_message_cb_data = NULL; // Removed
     g_swank_process_started = FALSE;
 
     g_debug("swank_process_cleanup_globals: Cleanup complete.");

--- a/opt/swank_process.h
+++ b/opt/swank_process.h
@@ -4,20 +4,16 @@
 #include <glib.h> // For gchar, gpointer, gboolean, GPid, GThread, etc.
 #include <gio/gio.h> // For GSocketConnection, GSocketClient
 
-// Callback type for stdout/stderr data
-typedef void (*GlobalProcessCallback)(GString *data, gpointer user_data);
+// Removed typedef GlobalProcessCallback - Callbacks are hardcoded
+// Removed typedef GlobalSwankProcessMessageCallback - Callback is hardcoded
 
 // Initializes the global process a single command string
 void process_init_globals(const gchar *cmd);
 
-// Initializes the global process from an argument vector
-void process_init_globals_from_argv(const gchar *const *argv);
+// process_init_globals_from_argv is now static
 
-// Sets the callback for stdout
-void process_global_set_stdout_cb(GlobalProcessCallback cb, gpointer user_data);
-
-// Sets the callback for stderr
-void process_global_set_stderr_cb(GlobalProcessCallback cb, gpointer user_data);
+// Removed process_global_set_stdout_cb - Callback is hardcoded
+// Removed process_global_set_stderr_cb - Callback is hardcoded
 
 // Writes data to the process's stdin
 gboolean process_global_write(const gchar *data, gssize len);
@@ -27,9 +23,6 @@ void process_global_start();
 
 // Cleans up global process resources (e.g., at application exit)
 void process_cleanup_globals();
-
-// Callback type for Swank messages
-typedef void (*GlobalSwankProcessMessageCallback)(GString *msg, gpointer user_data);
 
 // Initializes the global Swank process state.
 // It will internally use global preferences (for port) and global process functions.
@@ -41,11 +34,8 @@ void swank_process_global_start();
 // Sends a payload to the global Swank process
 void swank_process_global_send(const GString *payload);
 
-// Sets the message callback for the global Swank process
-void swank_process_global_set_message_cb(GlobalSwankProcessMessageCallback cb, gpointer user_data);
-
-// Allows setting the Swank socket FD directly (e.g., for testing or alternative connection methods)
-void swank_process_global_set_socket_fd(int fd);
+// Removed swank_process_global_set_message_cb - Callback is hardcoded
+// Removed swank_process_global_set_socket_fd - Unused function
 
 // Cleans up global Swank process resources
 void swank_process_cleanup_globals();

--- a/opt/swank_session.c
+++ b/opt/swank_session.c
@@ -120,7 +120,7 @@ static gchar *static_unescape_string(const char *token) {
 
 // --- Forward declarations for internal static functions (session specific) ---
 static void interaction_free_members_static(Interaction *interaction);
-static void swank_session_on_message_internal(GString *msg, gpointer user_data);
+// swank_session_on_message_internal is now non-static and declared in swank_session.h
 static gboolean swank_session_handle_message_on_main_thread(gpointer data);
 static void parse_and_handle_return_message(const gchar *message_payload);
 static gboolean parse_return_ok(const gchar *token, gchar **output, gchar **result);
@@ -152,8 +152,8 @@ void swank_session_init_globals() {
                                                                g_direct_equal,
                                                                NULL,
                                                                (GDestroyNotify)interaction_free_members_static);
-    swank_process_global_set_message_cb(swank_session_on_message_internal, NULL);
-    g_debug("swank_session_init_globals: Complete. Registered message callback.");
+    // swank_process_global_set_message_cb(swank_session_on_message_internal, NULL); // Callback is now hardcoded
+    g_debug("swank_session_init_globals: Complete.");
 }
 
 void swank_session_global_eval(Interaction *interaction) {
@@ -186,7 +186,8 @@ void swank_session_global_eval(Interaction *interaction) {
     g_string_free(payload, TRUE);
 }
 
-static void swank_session_on_message_internal(GString *msg, gpointer /*user_data*/) {
+// Made non-static to be called directly from swank_process.c
+void swank_session_on_message_internal(GString *msg, gpointer /*user_data*/) {
     g_debug_40("swank_session_on_message_internal: Received raw msg:", msg->str);
     MessageDataForMainThread *main_thread_data = g_new(MessageDataForMainThread, 1);
     main_thread_data->msg_payload = g_string_new_len(msg->str, msg->len);

--- a/opt/swank_session.h
+++ b/opt/swank_session.h
@@ -16,7 +16,8 @@ void swank_session_global_eval(Interaction *interaction);
 // Cleans up global Swank session resources (e.g., hash table).
 void swank_session_cleanup_globals();
 
-// The on_message callback is internal and registered with the global swank_process.
+// Function to handle messages from Swank, now called directly by swank_process.c
+void swank_session_on_message_internal(GString *msg, gpointer user_data);
 
 // InteractionsView is updated directly by new functions.
 


### PR DESCRIPTION
- Hardcoded callbacks in `swank_process.c` for stdout, stderr, and Swank messages, removing the need for dynamic callback setter functions.
- Removed `process_global_set_stdout_cb`, `process_global_set_stderr_cb`, and `swank_process_global_set_message_cb` and their associated global function pointer variables.
- Made `swank_session_on_message_internal` in `swank_session.c` non-static so it can be called directly from `swank_process.c`.
- Removed the unused function `swank_process_global_set_socket_fd`.
- Made `process_init_globals_from_argv` static as it's only used within `swank_process.c`.
- Cleaned up `swank_process.h` by removing declarations for the removed/static functions and unused typedefs.