### PR TITLE
Refactor: Remove 'global' and 'globals' suffix from symbols in opt/

### DIFF
--- a/opt/evaluate.c
+++ b/opt/evaluate.c
@@ -11,8 +11,8 @@
 #include <gtk/gtk.h>
 #include <gtksourceview/gtksource.h>
 
-// These globals are defined in main.c
-extern GtkSourceBuffer *buffer_global;
+// These variables are defined in main.c
+extern GtkSourceBuffer *buffer;
 #include "swank_session.h"
 
 
@@ -20,11 +20,11 @@ extern GtkSourceBuffer *buffer_global;
 /* Callback triggered when the user requests evaluation of the current line. */
 /* ------------------------------------------------------------------------- */
 void
-on_evaluate_global()
+on_evaluate()
 {
-  GtkSourceBuffer *source_buffer = buffer_global;
+  GtkSourceBuffer *source_buffer = buffer;
   if (!source_buffer) {
-    g_warning("Evaluate.on_evaluate_global: buffer_global is NULL");
+    g_warning("Evaluate.on_evaluate: buffer is NULL");
     return;
   }
 
@@ -52,10 +52,10 @@ on_evaluate_global()
   }
 
   /* 4. Send the expression to SWANK for remote execution. */
-  // Directly call the global eval function
+  // Directly call the eval function
   Interaction *interaction = g_new0(Interaction, 1);
   interaction_init(interaction, expr); // expr is owned by interaction now
-  swank_session_global_eval(interaction);
+  swank_session_eval(interaction);
   // Interaction will be managed (and eventually freed) by RealSwankSession logic.
 
 

--- a/opt/evaluate.h
+++ b/opt/evaluate.h
@@ -2,11 +2,11 @@
 #ifndef EVALUATE_H
 #define EVALUATE_H
 
-#include <gtksourceview/gtksource.h> // For GtkSourceBuffer used by on_evaluate_global if it were to take it
+#include <gtksourceview/gtksource.h> // For GtkSourceBuffer used by on_evaluate if it were to take it
 
-// on_evaluate_global is implemented in evaluate.c, which handles its own dependencies.
+// on_evaluate is implemented in evaluate.c, which handles its own dependencies.
 // This header only needs to declare the function.
 void
-on_evaluate_global();
+on_evaluate();
 
 #endif // EVALUATE_H

--- a/opt/main.c
+++ b/opt/main.c
@@ -20,53 +20,53 @@
 #include "reloc.c"
 #endif
 
-// Global variables
-GtkSourceBuffer *buffer_global = NULL;
-gchar           *filename_global = NULL;
-GtkWidget* interactions_view_global = NULL; // For SwankSession to call updates
+// Variables
+GtkSourceBuffer *buffer = NULL;
+gchar           *filename = NULL;
+GtkWidget* interactions_view_widget = NULL; // For SwankSession to call updates
 
 
 // Forward declarations for signal handlers
 static gboolean quit_delete_event_handler(GtkWidget *widget, GdkEvent *event, gpointer data);
 static void quit_menu_item_handler(GtkWidget *item, gpointer data);
 static gboolean on_key_press_handler(GtkWidget *widget, GdkEventKey *event, gpointer user_data);
-void on_evaluate_global();
+void on_evaluate();
 
 
 const gchar *main_get_filename() {
-    return filename_global;
+    return filename;
 }
 
 void main_set_filename(const gchar *new_filename) {
     gchar *dup = new_filename ? g_strdup(new_filename) : NULL;
-    g_free(filename_global);
-    filename_global = dup;
+    g_free(filename);
+    filename = dup;
 }
 
 GtkSourceBuffer *main_get_source_buffer() {
-    return buffer_global;
+    return buffer;
 }
 
-static void app_quit_global() {
+static void app_quit() {
   gtk_main_quit();
 }
 
-static void app_on_quit_global() {
-  app_quit_global();
+static void app_on_quit() {
+  app_quit();
 }
 
 static gboolean quit_delete_event_handler(GtkWidget * /*widget*/, GdkEvent * /*event*/, gpointer /*data*/) {
-  app_on_quit_global();
+  app_on_quit();
   return TRUE;
 }
 
 static void quit_menu_item_handler(GtkWidget * /*item*/, gpointer /*data*/) {
-  app_on_quit_global();
+  app_on_quit();
 }
 
 static gboolean on_key_press_handler(GtkWidget * /*widget*/, GdkEventKey *event, gpointer /*user_data*/) {
   if ((event->keyval == GDK_KEY_Return) && (event->state & GDK_MOD1_MASK)) {
-    on_evaluate_global();
+    on_evaluate();
     return TRUE;
   }
   return FALSE;
@@ -77,14 +77,14 @@ int main(int argc, char *argv[]) {
   relocate();
   gtk_init(&argc, &argv);
 
-  // Initialize global Process
-  process_init_globals("/usr/bin/sbcl");
+  // Initialize Process
+  process_init("/usr/bin/sbcl");
 
-  // Initialize global SwankProcess
-  swank_process_init_globals();
+  // Initialize SwankProcess
+  swank_process_init();
 
-  // Initialize global SwankSession
-  swank_session_init_globals();
+  // Initialize SwankSession
+  swank_session_init();
 
   // --- UI Setup ---
   GtkWidget *window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
@@ -96,9 +96,9 @@ int main(int argc, char *argv[]) {
 
   GtkSourceLanguageManager *lm = gtk_source_language_manager_get_default();
   GtkSourceLanguage *lang = gtk_source_language_manager_get_language(lm, "commonlisp");
-  buffer_global = gtk_source_buffer_new_with_language(lang);
+  buffer = gtk_source_buffer_new_with_language(lang);
 
-  GtkWidget *view = gtk_source_view_new_with_buffer(buffer_global);
+  GtkWidget *view = gtk_source_view_new_with_buffer(buffer);
   gtk_source_view_set_show_line_numbers(GTK_SOURCE_VIEW(view), TRUE);
   gtk_container_add(GTK_CONTAINER(scrolled), view);
 
@@ -119,17 +119,17 @@ int main(int argc, char *argv[]) {
   gtk_menu_shell_append(GTK_MENU_SHELL(file_menu), quit_item);
   gtk_menu_shell_append(GTK_MENU_SHELL(menu_bar), file_item);
 
-  // Connect to new global file operations
-  g_signal_connect(open_item, "activate", G_CALLBACK(simple_file_open_global), open_item);
-  g_signal_connect(save_item, "activate", G_CALLBACK(simple_file_save_global), save_item);
-  g_signal_connect(saveas_item, "activate", G_CALLBACK(simple_file_saveas_global), saveas_item);
+  // Connect to new file operations
+  g_signal_connect(open_item, "activate", G_CALLBACK(simple_file_open_ui), open_item);
+  g_signal_connect(save_item, "activate", G_CALLBACK(simple_file_save_ui), save_item);
+  g_signal_connect(saveas_item, "activate", G_CALLBACK(simple_file_saveas_ui), saveas_item);
   g_signal_connect(quit_item, "activate", G_CALLBACK(quit_menu_item_handler), NULL);
 
-  // Store the created InteractionsView globally for RealSwankSession to use.
-  interactions_view_global = GTK_WIDGET(interactions_view_new());
+  // Store the created InteractionsView for RealSwankSession to use.
+  interactions_view_widget = GTK_WIDGET(interactions_view_new());
   GtkWidget *paned = gtk_paned_new(GTK_ORIENTATION_VERTICAL);
   gtk_paned_pack1(GTK_PANED(paned), scrolled, TRUE, TRUE);
-  gtk_paned_pack2(GTK_PANED(paned), interactions_view_global, FALSE, TRUE);
+  gtk_paned_pack2(GTK_PANED(paned), interactions_view_widget, FALSE, TRUE);
 
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_box_pack_start(GTK_BOX(vbox), menu_bar, FALSE, FALSE, 0);

--- a/opt/simple_file_open.c
+++ b/opt/simple_file_open.c
@@ -8,19 +8,19 @@
 #include "reloc.h"    // For relocate() - though not used directly here, often in main
 #include "syscalls.h" // For sys_open, sys_read, sys_close, sys_fstat
 
-// Global variables defined in main.c
-extern GtkSourceBuffer *buffer_global;
+// Variables defined in main.c
+extern GtkSourceBuffer *buffer;
 extern void main_set_filename(const gchar *new_filename); // Defined in main.c
 
 
-void simple_file_open_global(GtkWidget *triggering_widget) {
+void simple_file_open_ui(GtkWidget *triggering_widget) {
     GtkWindow *parent_window = NULL;
     if (triggering_widget) {
         parent_window = GTK_WINDOW(gtk_widget_get_toplevel(triggering_widget));
     }
 
-    if (!buffer_global) {
-        g_printerr("simple_file_open_global: buffer_global is NULL. Cannot open file.\n");
+    if (!buffer) {
+        g_printerr("simple_file_open_ui: buffer is NULL. Cannot open file.\n");
         return;
     }
 
@@ -71,7 +71,7 @@ void simple_file_open_global(GtkWidget *triggering_widget) {
                     content[total_read] = '\0';
                     sys_close(fd);
 
-                    gtk_text_buffer_set_text(GTK_TEXT_BUFFER(buffer_global), content, -1);
+                    gtk_text_buffer_set_text(GTK_TEXT_BUFFER(buffer), content, -1);
                     g_free(content);
                 }
             }

--- a/opt/simple_file_open.h
+++ b/opt/simple_file_open.h
@@ -3,7 +3,7 @@
 
 #include <gtk/gtk.h> // For GtkWidget
 
-// Operates on global filename_global and buffer_global
-void simple_file_open_global(GtkWidget *triggering_widget);
+// Operates on buffer and filename (via main_get_filename, main_set_filename)
+void simple_file_open_ui(GtkWidget *triggering_widget);
 
 #endif // OPT_SIMPLE_FILE_OPEN_H

--- a/opt/simple_file_save.c
+++ b/opt/simple_file_save.c
@@ -9,14 +9,14 @@
 #include "reloc.h"
 #include "syscalls.h"
 
-// Global variables defined in main.c
-extern GtkSourceBuffer *buffer_global;
-// filename_global is managed via main_get_filename and main_set_filename
+// Variables defined in main.c
+extern GtkSourceBuffer *buffer;
+// filename is managed via main_get_filename and main_set_filename
 extern const gchar* main_get_filename();
 extern void main_set_filename(const gchar *new_filename);
 
 
-void simple_file_save_global(GtkWidget *triggering_widget) {
+void simple_file_save_ui(GtkWidget *triggering_widget) {
     GtkWindow *parent_window = NULL;
     if (triggering_widget) {
         parent_window = GTK_WINDOW(gtk_widget_get_toplevel(triggering_widget));
@@ -37,7 +37,7 @@ void simple_file_save_global(GtkWidget *triggering_widget) {
 
         if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
             filename_to_save = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
-            main_set_filename(filename_to_save); // Update global filename
+            main_set_filename(filename_to_save); // Update filename
         }
         gtk_widget_destroy(dialog);
 
@@ -45,13 +45,13 @@ void simple_file_save_global(GtkWidget *triggering_widget) {
             return;
         }
     } else {
-        filename_to_save = g_strdup(current_filename); // Use existing global filename
+        filename_to_save = g_strdup(current_filename); // Use existing filename
     }
 
     GtkTextIter start, end;
-    gtk_text_buffer_get_start_iter(GTK_TEXT_BUFFER(buffer_global), &start);
-    gtk_text_buffer_get_end_iter(GTK_TEXT_BUFFER(buffer_global), &end);
-    gchar *buffer_text = gtk_text_buffer_get_text(GTK_TEXT_BUFFER(buffer_global), &start, &end, FALSE);
+    gtk_text_buffer_get_start_iter(GTK_TEXT_BUFFER(buffer), &start);
+    gtk_text_buffer_get_end_iter(GTK_TEXT_BUFFER(buffer), &end);
+    gchar *buffer_text = gtk_text_buffer_get_text(GTK_TEXT_BUFFER(buffer), &start, &end, FALSE);
 
     int fd = sys_open(filename_to_save, O_WRONLY | O_CREAT | O_TRUNC, 0666);
     if (fd == -1) {
@@ -80,17 +80,17 @@ void simple_file_save_global(GtkWidget *triggering_widget) {
     g_free(filename_to_save); // Free if strdup'd or from chooser
 }
 
-void simple_file_saveas_global(GtkWidget *triggering_widget) {
-    // Store current filename, then set global to NULL to force Save As dialog in simple_file_save_global
+void simple_file_saveas_ui(GtkWidget *triggering_widget) {
+    // Store current filename, then set it to NULL to force Save As dialog in simple_file_save_ui
     gchar *original_filename_backup = NULL;
-    const gchar* current_global_filename = main_get_filename();
-    if (current_global_filename) {
-        original_filename_backup = g_strdup(current_global_filename);
+    const gchar* current_filename = main_get_filename();
+    if (current_filename) {
+        original_filename_backup = g_strdup(current_filename);
     }
 
-    main_set_filename(NULL); // Force simple_file_save_global to open "Save As" dialog
+    main_set_filename(NULL); // Force simple_file_save_ui to open "Save As" dialog
 
-    simple_file_save_global(triggering_widget);
+    simple_file_save_ui(triggering_widget);
 
     // If save was cancelled, main_get_filename() would still be NULL (or whatever new name if saved).
     // If it's NULL (cancelled), restore original.

--- a/opt/simple_file_save.h
+++ b/opt/simple_file_save.h
@@ -3,8 +3,8 @@
 
 #include <gtk/gtk.h> // For GtkWidget
 
-// Operates on global filename_global and buffer_global
-void simple_file_save_global(GtkWidget *triggering_widget);
-void simple_file_saveas_global(GtkWidget *triggering_widget);
+// Operates on filename and buffer (via main_get_filename, main_set_filename, main_get_source_buffer)
+void simple_file_save_ui(GtkWidget *triggering_widget);
+void simple_file_saveas_ui(GtkWidget *triggering_widget);
 
 #endif // OPT_SIMPLE_FILE_SAVE_H

--- a/opt/swank_process.c
+++ b/opt/swank_process.c
@@ -29,7 +29,7 @@ static GThread *g_process_err_thread = NULL;
 static gchar **g_process_argv = NULL;
 
 // Thread function to read stdout
-static gpointer stdout_thread_global(gpointer /*data*/) {
+static gpointer stdout_thread(gpointer /*data*/) {
   char buf[256];
   ssize_t n = 0;
   while (g_process_out_fd >= 0 && (n = sys_read(g_process_out_fd, buf, sizeof(buf))) > 0) {
@@ -41,7 +41,7 @@ static gpointer stdout_thread_global(gpointer /*data*/) {
 }
 
 // Thread function to read stderr
-static gpointer stderr_thread_global(gpointer /*data*/) {
+static gpointer stderr_thread(gpointer /*data*/) {
   char buf[256];
   ssize_t n = 0;
   while (g_process_err_fd >=0 && (n = sys_read(g_process_err_fd, buf, sizeof(buf))) > 0) {
@@ -53,31 +53,31 @@ static gpointer stderr_thread_global(gpointer /*data*/) {
 }
 
 // g_spawn_async_with_pipes child_setup function
-static void child_setup_global(gpointer /*user_data*/) {
+static void child_setup(gpointer /*user_data*/) {
   setsid(); // Create a new session and set process group ID.
   prctl(PR_SET_PDEATHSIG, SIGKILL); // Ensure child dies if parent dies.
 }
 
-// Initialize global process state from argv
-static void process_init_globals_from_argv(const gchar *const *argv) {
+// Initialize process state from argv
+static void process_init_from_argv(const gchar *const *argv) {
   g_strfreev(g_process_argv);
   g_process_argv = g_strdupv((gchar**)argv);
 }
 
-// Initialize global process state from a single command
-void process_init_globals(const gchar *cmd) {
+// Initialize process state from a single command
+void process_init(const gchar *cmd) {
   if (!cmd) {
-    g_warning("process_init_globals: cmd is NULL.");
-    process_init_globals_from_argv(NULL);
+    g_warning("process_init: cmd is NULL.");
+    process_init_from_argv(NULL);
     return;
   }
   const gchar *argv[] = { cmd, NULL };
-  process_init_globals_from_argv(argv);
+  process_init_from_argv(argv);
 }
 
-void process_global_start() {
+void process_start() {
   if (!g_process_argv || !g_process_argv[0]) {
-    g_printerr("process_global_start: No command (argv) to start.\n");
+    g_printerr("process_start: No command (argv) to start.\n");
     return;
   }
 
@@ -89,14 +89,14 @@ void process_global_start() {
                                 g_process_argv,
                                 NULL, // envp (current)
                                 G_SPAWN_DO_NOT_REAP_CHILD | G_SPAWN_SEARCH_PATH,
-                                child_setup_global, // function to run in child before exec
+                                child_setup, // function to run in child before exec
                                 NULL, // user_data for child_setup
                                 &g_process_pid,
                                 &g_process_in_fd,  // child's stdin
                                 &g_process_out_fd, // child's stdout
                                 &g_process_err_fd, // child's stderr
                                 &error)) {
-    g_printerr("process_global_start: g_spawn_async_with_pipes failed: %s\n", error ? error->message : "Unknown error");
+    g_printerr("process_start: g_spawn_async_with_pipes failed: %s\n", error ? error->message : "Unknown error");
     g_clear_error(&error);
     // Cleanup partially initialized state if spawn fails
     g_strfreev(g_process_argv);
@@ -109,17 +109,17 @@ void process_global_start() {
 
   // Start stdout thread if output FD is valid and thread not already running
   if (!g_process_out_thread && g_process_out_fd >=0) {
-    g_process_out_thread = g_thread_new("process-stdout", stdout_thread_global, NULL);
+    g_process_out_thread = g_thread_new("process-stdout", stdout_thread, NULL);
   }
   // Start stderr thread if error FD is valid and thread not already running
   if (!g_process_err_thread && g_process_err_fd >=0) {
-    g_process_err_thread = g_thread_new("process-stderr", stderr_thread_global, NULL);
+    g_process_err_thread = g_thread_new("process-stderr", stderr_thread, NULL);
   }
 }
 
-gboolean process_global_write(const gchar *data, gssize len) {
+gboolean process_write(const gchar *data, gssize len) {
   if (g_process_in_fd < 0) {
-    g_warning("process_global_write: Process not started or input FD is invalid.");
+    g_warning("process_write: Process not started or input FD is invalid.");
     return FALSE;
   }
   if (len < 0) {
@@ -127,16 +127,16 @@ gboolean process_global_write(const gchar *data, gssize len) {
   }
   ssize_t written = sys_write(g_process_in_fd, data, len);
   if (written == -1) {
-      g_printerr("process_global_write: write error to fd %d: %s (errno %d)\n", g_process_in_fd, g_strerror(errno), errno);
+      g_printerr("process_write: write error to fd %d: %s (errno %d)\n", g_process_in_fd, g_strerror(errno), errno);
   } else if (written < len) {
-      g_warning("process_global_write: partial write to fd %d. Wrote %zd of %zd bytes.", g_process_in_fd, written, len);
+      g_warning("process_write: partial write to fd %d. Wrote %zd of %zd bytes.", g_process_in_fd, written, len);
   }
   return written == len;
 }
 
 // --- End of Merged from process.c ---
 
-// Global static variables for SwankProcess's state (distinct from general process)
+// Static variables for SwankProcess's state (distinct from general process)
 static gint g_swank_fd = -1;
 static GSocketConnection *g_swank_connection = NULL; // Store the connection to manage its lifecycle
 
@@ -153,12 +153,12 @@ static gint    g_swank_port_number = 4005; // Default, will be updated from glob
 static GThread *g_swank_reader_thread = NULL;
 
 // --- Forward declarations for internal static functions ---
-static gpointer swank_reader_thread_global(gpointer data);
+static gpointer swank_reader_thread(gpointer data);
 static void read_until_from_lisp_output(const char *pattern);
 static void start_lisp_and_swank_server();
 static void connect_to_swank_server();
 
-void swank_process_init_globals() {
+void swank_process_init() {
 
     // Initialize mutexes and cond var
     g_mutex_init(&g_swank_out_mutex);
@@ -171,7 +171,7 @@ void swank_process_init_globals() {
 
 }
 
-static gpointer swank_reader_thread_global(gpointer /*data*/) {
+static gpointer swank_reader_thread(gpointer /*data*/) {
     char buf[1024]; // Read buffer
     ssize_t n_read;
 
@@ -228,7 +228,7 @@ static gpointer swank_reader_thread_global(gpointer /*data*/) {
                 g_usleep(10000); // Sleep a bit and retry
                 continue;
             }
-            g_printerr("swank_process: swank_reader_thread_global read error on fd %d: %s (errno %d)\n", g_swank_fd, g_strerror(errno), errno);
+            g_printerr("swank_process: swank_reader_thread read error on fd %d: %s (errno %d)\n", g_swank_fd, g_strerror(errno), errno);
             break;
         }
     }
@@ -272,7 +272,7 @@ static void on_lisp_stderr(GString *data) {
 
 static void start_lisp_and_swank_server() {
 
-    process_global_start(); // Start the Lisp process
+    process_start(); // Start the Lisp process
 
     // Wait for Lisp prompt (e.g., "* ")
     read_until_from_lisp_output("* "); // This pattern may need to be more robust or configurable.
@@ -280,7 +280,7 @@ static void start_lisp_and_swank_server() {
     // This command depends on the Lisp implementation (e.g., ql:quickload vs require).
     // Using (require :swank) for now.
     const char *load_swank_cmd = "(require :swank)\n";
-    process_global_write(load_swank_cmd, -1);
+    process_write(load_swank_cmd, -1);
 
     read_until_from_lisp_output(")"); // A simple heuristic: wait for some closing paren. This needs improvement.
     read_until_from_lisp_output("* "); // Wait for prompt again
@@ -288,7 +288,7 @@ static void start_lisp_and_swank_server() {
     char create_server_cmd[128];
     g_snprintf(create_server_cmd, sizeof(create_server_cmd),
                "(swank:create-server :port %d :dont-close t)\n", g_swank_port_number);
-    process_global_write(create_server_cmd, -1);
+    process_write(create_server_cmd, -1);
 
     // Wait for Swank server to report its port or for prompt again
     read_until_from_lisp_output("* "); // Or a specific message like ";; Swank started on port XXXX."
@@ -329,23 +329,23 @@ static void connect_to_swank_server() {
     // Make the socket blocking for sys_read if necessary, or adapt sys_read logic.
     // For simplicity, we assume sys_read handles non-blocking behavior or FD is blocking.
     // If GSocket FD is non-blocking by default, sys_read might return EAGAIN.
-    // The swank_reader_thread_global has a basic EAGAIN check.
+    // The swank_reader_thread has a basic EAGAIN check.
 
 
     // Start the Swank message reader thread
     if (g_swank_fd >=0 && !g_swank_reader_thread) {
-        g_swank_reader_thread = g_thread_new("swank-reader", swank_reader_thread_global, NULL);
+        g_swank_reader_thread = g_thread_new("swank-reader", swank_reader_thread, NULL);
     }
 }
 
-void swank_process_global_start() {
-    start_lisp_and_swank_server(); // This starts the underlying Lisp process via process_global_start()
+void swank_process_start() {
+    start_lisp_and_swank_server(); // This starts the underlying Lisp process via process_start()
     connect_to_swank_server();
 }
 
-void swank_process_global_send(const GString *payload) {
+void swank_process_send(const GString *payload) {
     if (g_swank_fd < 0) {
-        g_warning("swank_process_global_send: Swank process not started or FD invalid.");
+        g_warning("swank_process_send: Swank process not started or FD invalid.");
         return;
     }
 
@@ -356,14 +356,14 @@ void swank_process_global_send(const GString *payload) {
 
     ssize_t nw_hdr = sys_write(g_swank_fd, hdr, 6);
     if (nw_hdr != 6) {
-        g_printerr("swank_process_global_send: Failed to write Swank header (wrote %zd, errno %d)\n", nw_hdr, errno);
+        g_printerr("swank_process_send: Failed to write Swank header (wrote %zd, errno %d)\n", nw_hdr, errno);
         // Consider this a critical failure; perhaps reset state or attempt reconnect.
         return;
     }
 
     ssize_t nw_payload = sys_write(g_swank_fd, payload->str, len);
     if (nw_payload != (ssize_t)len) {
-        g_printerr("swank_process_global_send: Failed to write Swank payload (wrote %zd of %zu, errno %d)\n", nw_payload, len, errno);
+        g_printerr("swank_process_send: Failed to write Swank payload (wrote %zd of %zu, errno %d)\n", nw_payload, len, errno);
         return;
     }
 }

--- a/opt/swank_process.h
+++ b/opt/swank_process.h
@@ -4,31 +4,31 @@
 #include <glib.h> // For gchar, gpointer, gboolean, GPid, GThread, etc.
 #include <gio/gio.h> // For GSocketConnection, GSocketClient
 
-// Initializes the global process a single command string
-void process_init_globals(const gchar *cmd);
+// Initializes the process a single command string
+void process_init(const gchar *cmd);
 
-// process_init_globals_from_argv is now static
+// process_init_from_argv is now static
 
 // Writes data to the process's stdin
-gboolean process_global_write(const gchar *data, gssize len);
+gboolean process_write(const gchar *data, gssize len);
 
 // Starts the process execution
-void process_global_start();
+void process_start();
 
-// Cleans up global process resources (e.g., at application exit)
-void process_cleanup_globals();
+// Cleans up process resources (e.g., at application exit)
+void process_cleanup();
 
-// Initializes the global Swank process state.
-// It will internally use global preferences (for port) and global process functions.
-void swank_process_init_globals();
+// Initializes the Swank process state.
+// It will internally use preferences (for port) and process functions.
+void swank_process_init();
 
-// Starts the global Swank process (which includes starting the underlying process if not already started)
-void swank_process_global_start();
+// Starts the Swank process (which includes starting the underlying process if not already started)
+void swank_process_start();
 
-// Sends a payload to the global Swank process
-void swank_process_global_send(const GString *payload);
+// Sends a payload to the Swank process
+void swank_process_send(const GString *payload);
 
-// Cleans up global Swank process resources
-void swank_process_cleanup_globals();
+// Cleans up Swank process resources
+void swank_process_cleanup();
 
 #endif /* SWANK_PROCESS_H */

--- a/opt/swank_session.c
+++ b/opt/swank_session.c
@@ -6,8 +6,8 @@
 #include <string.h>       // For strstr, etc.
 #include <gtk/gtk.h>      // For g_main_context_invoke, if message handling needs to be on main thread
 
-// Global static variables for SwankSession's state
-extern GtkWidget* interactions_view_global; // Defined in main.c
+// Static variables for SwankSession's state
+extern GtkWidget* interactions_view_widget; // Defined in main.c
 static gboolean   g_swank_session_started = FALSE;
 static guint32    g_swank_session_next_tag = 1;
 static GHashTable *g_swank_session_interactions_table = NULL; // Stores Interaction* keyed by tag
@@ -126,7 +126,7 @@ typedef struct {
     GString *msg_payload;
 } MessageDataForMainThread;
 
-void swank_session_init_globals() {
+void swank_session_init() {
     g_swank_session_started = FALSE;
     g_swank_session_next_tag = 1;
     g_swank_session_interactions_table = g_hash_table_new_full(g_direct_hash,
@@ -135,26 +135,26 @@ void swank_session_init_globals() {
                                                                NULL);
 }
 
-void swank_session_global_eval(Interaction *interaction) {
+void swank_session_eval(Interaction *interaction) {
     if (!interaction || !interaction->expression) {
         if(interaction) g_free(interaction);
         return;
     }
     if (!g_swank_session_started) {
-        swank_process_global_start();
+        swank_process_start();
         g_swank_session_started = TRUE;
     }
     interaction->tag = g_swank_session_next_tag++;
     interaction->status = INTERACTION_RUNNING;
     g_hash_table_insert(g_swank_session_interactions_table, GUINT_TO_POINTER(interaction->tag), interaction);
-    interactions_view_add_interaction(GLIDE_INTERACTIONS_VIEW(interactions_view_global), interaction);
+    interactions_view_add_interaction(GLIDE_INTERACTIONS_VIEW(interactions_view_widget), interaction);
     gchar *escaped_expr = escape_string(interaction->expression); // Uses static_escape_string
     gchar *rpc_call = g_strdup_printf("(:emacs-rex (swank:eval-and-grab-output \"%s\") \"COMMON-LISP-USER\" t %u)",
                                       escaped_expr, interaction->tag);
     g_free(escaped_expr);
     GString *payload = g_string_new(rpc_call);
     g_free(rpc_call);
-    swank_process_global_send(payload);
+    swank_process_send(payload);
     g_string_free(payload, TRUE);
 }
 
@@ -219,7 +219,7 @@ static void parse_and_handle_return_message(const char *message_payload_str) {
         g_free(interaction->error);
         interaction->error = g_strdup("Failed to parse return from Swank");
     }
-    interactions_view_update_interaction(GLIDE_INTERACTIONS_VIEW(interactions_view_global), interaction);
+    interactions_view_update_interaction(GLIDE_INTERACTIONS_VIEW(interactions_view_widget), interaction);
     g_free(return_type_token);
     g_free(tag_id_token);
 }

--- a/opt/swank_session.h
+++ b/opt/swank_session.h
@@ -4,17 +4,17 @@
 #include <glib.h>
 #include "interaction.h" // For Interaction struct, used in eval
 
-// Initializes the global Swank session state.
-// It will internally set itself up as the callback for the global Swank process.
-void swank_session_init_globals();
+// Initializes the Swank session state.
+// It will internally set itself up as the callback for the Swank process.
+void swank_session_init();
 
-// Evaluates an expression using the global Swank session.
+// Evaluates an expression using the Swank session.
 // The Interaction object should be allocated by the caller and will be managed (and eventually freed)
 // by the SwankSession logic or through explicit cleanup if needed.
-void swank_session_global_eval(Interaction *interaction);
+void swank_session_eval(Interaction *interaction);
 
-// Cleans up global Swank session resources (e.g., hash table).
-void swank_session_cleanup_globals();
+// Cleans up Swank session resources (e.g., hash table).
+void swank_session_cleanup();
 
 // Function to handle messages from Swank, now called directly by swank_process.c
 void swank_session_on_message_internal(GString *msg, gpointer user_data);


### PR DESCRIPTION
Removed the 'global' or 'globals' suffix from functions and variable names within the 'opt/' directory.

This includes updates to:
- Function definitions and declarations
- Variable declarations and usages
- String literals and comments referring to these symbols

The changes were made across .c and .h files in opt/, including main.c, evaluate.c/h, simple_file_open.c/h, simple_file_save.c/h, swank_process.c/h, and swank_session.c/h.

Build successful after renaming and installing necessary dependencies.