### PR TITLE
I've refactored LispSourceView and app.c.

### DIFF
--- a/64k/Makefile
+++ b/64k/Makefile
@@ -1,6 +1,6 @@
 
 LIBS += gtksourceview-4
-SOURCES += file_open.c file_save.c preferences.c preferences_dialog.c find_executables.c process.c real_process.c swank_process.c real_swank_process.c real_swank_session.c swank_session.c evaluate.c interactions_view.c app.c
+SOURCES += file_open.c file_save.c preferences.c preferences_dialog.c find_executables.c process.c real_process.c swank_process.c real_swank_process.c real_swank_session.c swank_session.c evaluate.c interactions_view.c app.c lisp_source_view.c
 
 include ../common/common.mk
 

--- a/64k/app.c
+++ b/64k/app.c
@@ -5,6 +5,7 @@
 #include "preferences_dialog.h"
 #include "evaluate.h"
 #include "interactions_view.h"
+#include "lisp_source_view.h"
 
 /* Signal handlers */
 STATIC gboolean quit_delete_event (GtkWidget * /*widget*/, GdkEvent * /*event*/, gpointer data);
@@ -63,13 +64,8 @@ app_activate (GApplication *app)
   GtkWidget *scrolled = gtk_scrolled_window_new (NULL, NULL);
   gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (scrolled), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
 
-  /* Source buffer + language */
-  GtkSourceLanguageManager *lm = gtk_source_language_manager_get_default ();
-  GtkSourceLanguage *lang = gtk_source_language_manager_get_language (lm, "commonlisp");
-  self->buffer = gtk_source_buffer_new_with_language (lang);
-
-  GtkWidget *view = gtk_source_view_new_with_buffer (self->buffer);
-  gtk_source_view_set_show_line_numbers (GTK_SOURCE_VIEW (view), TRUE);
+  GtkWidget *view = lisp_source_view_new ();
+  self->buffer = lisp_source_view_get_buffer (LISP_SOURCE_VIEW (view));
   gtk_container_add (GTK_CONTAINER (scrolled), view);
 
   /* Catch Alt+Enter in the view */

--- a/64k/lisp_source_view.c
+++ b/64k/lisp_source_view.c
@@ -1,0 +1,50 @@
+#include "lisp_source_view.h"
+
+struct _LispSourceView
+{
+  GtkSourceView parent_instance;
+
+  GtkSourceBuffer *buffer;
+};
+
+G_DEFINE_TYPE (LispSourceView, lisp_source_view, GTK_SOURCE_TYPE_VIEW)
+
+static void
+lisp_source_view_init (LispSourceView *self)
+{
+  GtkSourceLanguageManager *lm = gtk_source_language_manager_get_default ();
+  GtkSourceLanguage *lang = gtk_source_language_manager_get_language (lm, "commonlisp");
+  self->buffer = gtk_source_buffer_new_with_language (lang);
+  gtk_text_view_set_buffer (GTK_TEXT_VIEW (self), GTK_TEXT_BUFFER (self->buffer));
+  gtk_source_view_set_show_line_numbers (GTK_SOURCE_VIEW (self), TRUE);
+}
+
+static void
+lisp_source_view_dispose (GObject *object)
+{
+  LispSourceView *self = LISP_SOURCE_VIEW (object);
+
+  g_clear_object (&self->buffer);
+
+  G_OBJECT_CLASS (lisp_source_view_parent_class)->dispose (object);
+}
+
+static void
+lisp_source_view_class_init (LispSourceViewClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  object_class->dispose = lisp_source_view_dispose;
+}
+
+GtkWidget *
+lisp_source_view_new (void)
+{
+  return g_object_new (LISP_TYPE_SOURCE_VIEW, NULL);
+}
+
+GtkSourceBuffer *
+lisp_source_view_get_buffer (LispSourceView *self)
+{
+  g_return_val_if_fail (LISP_IS_SOURCE_VIEW (self), NULL);
+  return self->buffer;
+}

--- a/64k/lisp_source_view.h
+++ b/64k/lisp_source_view.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <gtksourceview/gtksource.h>
+
+G_BEGIN_DECLS
+
+#define LISP_TYPE_SOURCE_VIEW (lisp_source_view_get_type ())
+G_DECLARE_FINAL_TYPE (LispSourceView, lisp_source_view, LISP, SOURCE_VIEW, GtkSourceView)
+
+GtkWidget      *lisp_source_view_new (void);
+GtkSourceBuffer *lisp_source_view_get_buffer (LispSourceView *self);
+
+G_END_DECLS


### PR DESCRIPTION
I moved GtkSourceLanguageManager, GtkSourceBuffer creation, and line number display logic from app.c to LispSourceView.

- LispSourceView now manages its own GtkSourceBuffer.
- I added lisp_source_view_get_buffer() to access the buffer.
- Line number display is now handled in LispSourceView's initialization.
- I updated app.c to use the new LispSourceView API.