### PR TITLE
I've refactored lisp_parser.c to produce a token stream and a custom …

### DIFF
--- a/64k/lisp-parser.c
+++ b/64k/lisp-parser.c
@@ -6,72 +6,56 @@
 
 // Define the LispParser structure
 struct _LispParser {
-    GNode *ast_root;
-    GtkSourceBuffer *buffer; // Not owned by the parser
+    GtkSourceBuffer *buffer; // Not owned
+    GArray *tokens;          // Owns LispToken structs
+    LispAstNode *ast;        // Owns the AST
+    // GArray of GError pointers for parsing errors
+    GArray *errors;
 };
 
-// --- LispSyntaxElement Helpers ---
+// --- Forward Declarations for Static Functions ---
+static void lisp_parser_clear_data(LispParser *parser);
+static void lisp_token_free(gpointer token);
+static void lisp_ast_node_free(LispAstNode *node);
+static LispAstNode* parse_expression(const GArray *tokens, guint *position, GArray *errors);
 
-/**
- * lisp_syntax_element_new: (static)
- * @type: The type of the syntax element.
- * @text: The text content of the element. Can be NULL. Will be duplicated.
- * @start: Pointer to the start GtkTextIter. Can be NULL.
- * @end: Pointer to the end GtkTextIter. Can be NULL.
- *
- * Allocates and initializes a new LispSyntaxElement.
- * Text is copied. Iterators are copied.
- *
- * Returns: (transfer full): A new LispSyntaxElement, or NULL on allocation failure.
- */
-static LispSyntaxElement* lisp_syntax_element_new(LispSyntaxElementType type,
-                                                  const gchar *text,
-                                                  const GtkTextIter *start,
-                                                  const GtkTextIter *end) {
-    LispSyntaxElement *element = g_new(LispSyntaxElement, 1);
-    if (!element) { // g_new aborts on failure by default, but defensive check is fine.
-        return NULL;
-    }
+// --- Memory Management ---
 
-    element->type = type;
-    element->text = text ? g_strdup(text) : NULL;
-
-    if (start) {
-        element->start_iter = *start;
-    } else {
-        memset(&element->start_iter, 0, sizeof(GtkTextIter)); // Initialize to a zeroed/invalid state
-    }
-    if (end) {
-        element->end_iter = *end;
-    } else {
-        memset(&element->end_iter, 0, sizeof(GtkTextIter)); // Initialize to a zeroed/invalid state
-    }
-
-    return element;
+static void lisp_token_free(gpointer token) {
+    if (!token) return;
+    LispToken *t = (LispToken*)token;
+    g_free(t->text);
+    // The struct itself is part of the GArray's chunk, so no need to g_free(t)
 }
 
-/**
- * lisp_syntax_element_free: (Public, declared in header)
- * @data: A pointer to a LispSyntaxElement.
- *
- * Frees a LispSyntaxElement, including its text.
- */
-void lisp_syntax_element_free(gpointer data) {
-    if (!data) {
-        return;
+static void lisp_ast_node_free(LispAstNode *node) {
+    if (!node) return;
+
+    if (node->children) {
+        for (guint i = 0; i < node->children->len; i++) {
+            lisp_ast_node_free(g_array_index(node->children, LispAstNode*, i));
+        }
+        g_array_free(node->children, TRUE);
     }
-    LispSyntaxElement *element = (LispSyntaxElement *)data;
-    g_free(element->text);
-    g_free(element);
+    g_free(node);
 }
 
-// Adapter function for g_node_traverse to free LispSyntaxElement data
-static gboolean lisp_syntax_element_free_node_data_cb(GNode *node, gpointer user_data G_GNUC_UNUSED) {
-    if (node->data) {
-        lisp_syntax_element_free(node->data);
-        node->data = NULL;
+// Clears tokens, AST, and errors from the parser
+static void lisp_parser_clear_data(LispParser *parser) {
+    if (parser->tokens) {
+        g_array_set_clear_func(parser->tokens, lisp_token_free);
+        g_array_free(parser->tokens, TRUE);
+        parser->tokens = NULL;
     }
-    return FALSE; // Continue traversal
+    if (parser->ast) {
+        lisp_ast_node_free(parser->ast);
+        parser->ast = NULL;
+    }
+    if (parser->errors) {
+        g_array_set_clear_func(parser->errors, (GDestroyNotify)g_error_free);
+        g_array_free(parser->errors, TRUE);
+        parser->errors = NULL;
+    }
 }
 
 
@@ -80,226 +64,223 @@ static gboolean lisp_syntax_element_free_node_data_cb(GNode *node, gpointer user
 LispParser *lisp_parser_new(GtkSourceBuffer *buffer) {
     g_return_val_if_fail(GTK_SOURCE_IS_BUFFER(buffer), NULL);
 
-    LispParser *parser = g_new(LispParser, 1);
-
+    LispParser *parser = g_new0(LispParser, 1);
     parser->buffer = buffer;
-    parser->ast_root = NULL;
-
-    LispSyntaxElement *root_doc_element = lisp_syntax_element_new(LISP_SYNTAX_ELEMENT_DOCUMENT_ROOT,
-                                                                  "DOCUMENT_ROOT", NULL, NULL);
-    if (!root_doc_element) {
-        g_free(parser);
-        return NULL;
-    }
-    parser->ast_root = g_node_new(root_doc_element);
-    if (!parser->ast_root) {
-        lisp_syntax_element_free(root_doc_element);
-        g_free(parser);
-        return NULL;
-    }
+    // Other fields are initialized to NULL by g_new0
 
     return parser;
 }
 
 void lisp_parser_free(LispParser *parser) {
     g_return_if_fail(parser != NULL);
-
-    if (parser->ast_root) {
-        g_node_traverse(parser->ast_root,
-                        G_POST_ORDER,
-                        G_TRAVERSE_ALL,
-                        -1,
-                        lisp_syntax_element_free_node_data_cb,
-                        NULL);
-
-        g_node_destroy(parser->ast_root);
-        parser->ast_root = NULL;
-    }
-
+    lisp_parser_clear_data(parser);
     g_free(parser);
 }
 
-GNode *lisp_parser_get_ast_root(LispParser *parser) {
+const LispAstNode *lisp_parser_get_ast(LispParser *parser) {
     g_return_val_if_fail(parser != NULL, NULL);
-    return parser->ast_root;
+    return parser->ast;
+}
+
+const LispToken *lisp_parser_get_tokens(LispParser *parser, guint *n_tokens) {
+    g_return_val_if_fail(parser != NULL, NULL);
+    if (n_tokens) {
+        *n_tokens = parser->tokens ? parser->tokens->len : 0;
+    }
+    return parser->tokens ? (const LispToken*)parser->tokens->pdata : NULL;
 }
 
 void lisp_parser_parse(LispParser *parser) {
     g_return_if_fail(parser != NULL);
     g_return_if_fail(GTK_SOURCE_IS_BUFFER(parser->buffer));
 
-    // 1. Clear existing AST data and structure
-    if (parser->ast_root) {
-        g_node_traverse(parser->ast_root, G_POST_ORDER, G_TRAVERSE_ALL, -1,
-                        lisp_syntax_element_free_node_data_cb, NULL);
-        g_node_destroy(parser->ast_root);
-        parser->ast_root = NULL;
-    }
+    // 1. Clear previous results
+    lisp_parser_clear_data(parser);
 
-    // 2. Create a new root for the new parse
-    LispSyntaxElement *root_element = lisp_syntax_element_new(LISP_SYNTAX_ELEMENT_DOCUMENT_ROOT,
-                                                              "DOCUMENT_ROOT", NULL, NULL);
-    if (!root_element) {
-        g_warning("Failed to create root syntax element for parsing.");
-        return;
-    }
-    parser->ast_root = g_node_new(root_element);
-    if (!parser->ast_root) {
-        lisp_syntax_element_free(root_element);
-        g_warning("Failed to create root GNode for parsing AST.");
-        return;
-    }
+    // Initialize storage for new results
+    parser->tokens = g_array_new(FALSE, TRUE, sizeof(LispToken));
+    parser->errors = g_array_new(FALSE, TRUE, sizeof(GError*));
 
-    // --- Actual parsing logic ---
-
-    GtkTextIter current_iter, token_start_iter;
+    // 2. Tokenization Stage
+    GtkTextIter current_iter;
     gtk_text_buffer_get_start_iter(GTK_TEXT_BUFFER(parser->buffer), &current_iter);
-
-    // Stack to keep track of current parent GNode for nesting lists
-    GArray *node_stack = g_array_new(FALSE, FALSE, sizeof(GNode*));
-    g_array_append_val(node_stack, parser->ast_root); // Start with document root as current parent
 
     while (!gtk_text_iter_is_end(&current_iter)) {
         gunichar current_char = gtk_text_iter_get_char(&current_iter);
-        LispSyntaxElementType current_element_type;
-        gchar *token_text = NULL;
+        LispToken token = {0};
+        token.start_iter = current_iter;
 
-        token_start_iter = current_iter; // Mark start of the current token
-
-        if (current_char == '(') {
-            current_element_type = LISP_SYNTAX_ELEMENT_LIST_START;
-            GtkTextIter temp_end_iter = current_iter;
-            gtk_text_iter_forward_char(&temp_end_iter);
-            token_text = gtk_text_iter_get_text(&token_start_iter, &temp_end_iter);
-            current_iter = temp_end_iter; // Advance main iterator
+        if (g_unichar_isspace(current_char)) {
+            token.type = LISP_TOKEN_TYPE_WHITESPACE;
+            GtkTextIter end_iter = current_iter;
+            while (!gtk_text_iter_is_end(&end_iter) && g_unichar_isspace(gtk_text_iter_get_char(&end_iter))) {
+                gtk_text_iter_forward_char(&end_iter);
+            }
+            token.end_iter = end_iter;
+            current_iter = end_iter;
+        } else if (current_char == ';') {
+            token.type = LISP_TOKEN_TYPE_COMMENT;
+            GtkTextIter end_iter = current_iter;
+            while (!gtk_text_iter_is_end(&end_iter) && gtk_text_iter_get_char(&end_iter) != '\n') {
+                gtk_text_iter_forward_char(&end_iter);
+            }
+            token.end_iter = end_iter;
+            current_iter = end_iter;
+        } else if (current_char == '(') {
+            token.type = LISP_TOKEN_TYPE_LIST_START;
+            gtk_text_iter_forward_char(&current_iter);
+            token.end_iter = current_iter;
         } else if (current_char == ')') {
-            current_element_type = LISP_SYNTAX_ELEMENT_LIST_END;
-            GtkTextIter temp_end_iter = current_iter;
-            gtk_text_iter_forward_char(&temp_end_iter);
-            token_text = gtk_text_iter_get_text(&token_start_iter, &temp_end_iter);
-            current_iter = temp_end_iter; // Advance main iterator
-        } else if (current_char == '"') { // String
-            GtkTextIter str_end_iter = current_iter;
-            gtk_text_iter_forward_char(&str_end_iter); // Move past opening "
-            gboolean found_end_quote = FALSE;
-            while (!gtk_text_iter_is_end(&str_end_iter)) {
-                gunichar str_char = gtk_text_iter_get_char(&str_end_iter);
-                if (str_char == '\\') {
-                    gtk_text_iter_forward_char(&str_end_iter); // Skip char after '\'
-                    if (gtk_text_iter_is_end(&str_end_iter)) break;
-                } else if (str_char == '"') {
-                    found_end_quote = TRUE;
-                    gtk_text_iter_forward_char(&str_end_iter); // Include closing "
+            token.type = LISP_TOKEN_TYPE_LIST_END;
+            gtk_text_iter_forward_char(&current_iter);
+            token.end_iter = current_iter;
+        } else if (current_char == '"') {
+            GtkTextIter end_iter = current_iter;
+            gtk_text_iter_forward_char(&end_iter); // Skip opening quote
+            gboolean escaped = FALSE;
+            gboolean found_end = FALSE;
+            while (!gtk_text_iter_is_end(&end_iter)) {
+                gunichar c = gtk_text_iter_get_char(&end_iter);
+                if (escaped) {
+                    escaped = FALSE;
+                } else if (c == '\\') {
+                    escaped = TRUE;
+                } else if (c == '"') {
+                    found_end = TRUE;
+                    gtk_text_iter_forward_char(&end_iter);
                     break;
                 }
-                gtk_text_iter_forward_char(&str_end_iter);
+                gtk_text_iter_forward_char(&end_iter);
             }
-            token_text = gtk_text_iter_get_text(&token_start_iter, &str_end_iter);
-            current_element_type = found_end_quote ? LISP_SYNTAX_ELEMENT_STRING : LISP_SYNTAX_ELEMENT_INCOMPLETE_STRING;
-            current_iter = str_end_iter; // Advance main iterator
-        } else if (current_char == ';') { // Comment
-            current_element_type = LISP_SYNTAX_ELEMENT_COMMENT;
-            GtkTextIter comment_end_iter = current_iter;
-            while (!gtk_text_iter_is_end(&comment_end_iter) && gtk_text_iter_get_char(&comment_end_iter) != '\n') {
-                gtk_text_iter_forward_char(&comment_end_iter);
-            }
-            // Optionally include newline: if (!gtk_text_iter_is_end(&comment_end_iter)) gtk_text_iter_forward_char(&comment_end_iter);
-            token_text = gtk_text_iter_get_text(&token_start_iter, &comment_end_iter);
-            current_iter = comment_end_iter; // Advance main iterator
-        } else if (g_unichar_isspace(current_char)) {
-            current_element_type = LISP_SYNTAX_ELEMENT_WHITESPACE;
-            GtkTextIter ws_end_iter = current_iter;
-            while (!gtk_text_iter_is_end(&ws_end_iter) && g_unichar_isspace(gtk_text_iter_get_char(&ws_end_iter))) {
-                gtk_text_iter_forward_char(&ws_end_iter);
-            }
-            token_text = gtk_text_iter_get_text(&token_start_iter, &ws_end_iter);
-            current_iter = ws_end_iter; // Advance main iterator
+            token.type = found_end ? LISP_TOKEN_TYPE_STRING : LISP_TOKEN_TYPE_INCOMPLETE_STRING;
+            token.end_iter = end_iter;
+            current_iter = end_iter;
         } else { // Atom
-            current_element_type = LISP_SYNTAX_ELEMENT_ATOM;
-            GtkTextIter atom_end_iter = current_iter;
-            while (!gtk_text_iter_is_end(&atom_end_iter)) {
-                gunichar atom_char = gtk_text_iter_get_char(&atom_end_iter);
-                if (g_unichar_isspace(atom_char) || atom_char == '(' || atom_char == ')' ||
-                    atom_char == '"' || atom_char == ';') {
+            token.type = LISP_TOKEN_TYPE_ATOM;
+            GtkTextIter end_iter = current_iter;
+            while (!gtk_text_iter_is_end(&end_iter)) {
+                gunichar c = gtk_text_iter_get_char(&end_iter);
+                if (g_unichar_isspace(c) || c == '(' || c == ')' || c == '"' || c == ';') {
                     break;
                 }
-                gtk_text_iter_forward_char(&atom_end_iter);
+                gtk_text_iter_forward_char(&end_iter);
             }
-            token_text = gtk_text_iter_get_text(&token_start_iter, &atom_end_iter);
-            current_iter = atom_end_iter; // Advance main iterator
+            token.end_iter = end_iter;
+            current_iter = end_iter;
+        }
 
-            if (token_text == NULL || strlen(token_text) == 0) {
-                g_free(token_text); // token_text would be "" if start == end, g_strdup("") is valid
-                // This can happen if buffer ends with a delimiter or multiple delimiters
-                // or if gtk_text_iter_is_end(&current_iter) was false but current_iter was already at the very end.
-                // No element to create, just continue.
+        token.text = gtk_text_iter_get_text(&token.start_iter, &token.end_iter);
+        g_array_append_val(parser->tokens, token);
+    }
+
+    // 3. AST Construction Stage
+    guint position = 0;
+    // The AST for a file is implicitly a list of top-level expressions.
+    // We'll create a root node to hold them.
+    parser->ast = g_new0(LispAstNode, 1);
+    parser->ast->type = LISP_AST_NODE_TYPE_LIST; // Root is a list of expressions
+    parser->ast->children = g_array_new(FALSE, FALSE, sizeof(LispAstNode*));
+    // Root node doesn't correspond to a specific token.
+
+    while(position < parser->tokens->len) {
+        // Skip non-content tokens at the top level
+        const LispToken *token = &g_array_index(parser->tokens, LispToken, position);
+        if(token->type == LISP_TOKEN_TYPE_WHITESPACE || token->type == LISP_TOKEN_TYPE_COMMENT) {
+            position++;
+            continue;
+        }
+
+        LispAstNode *expr = parse_expression(parser->tokens, &position, parser->errors);
+        if (expr) {
+            g_array_append_val(parser->ast->children, expr);
+        } else {
+            // If parse_expression returns NULL, it means an error occurred.
+            // The error is already in the errors list. We should stop or try to recover.
+            // For now, we'll stop. A more robust parser might try to find the next valid expression start.
+            break;
+        }
+    }
+}
+
+static LispAstNode* parse_expression(const GArray *tokens, guint *position, GArray *errors) {
+    // Skip leading whitespace/comments for the current expression
+    while (*position < tokens->len) {
+        const LispToken *token = &g_array_index(tokens, LispToken, *position);
+        if (token->type != LISP_TOKEN_TYPE_WHITESPACE && token->type != LISP_TOKEN_TYPE_COMMENT) {
+            break;
+        }
+        (*position)++;
+    }
+
+    if (*position >= tokens->len) {
+        return NULL; // End of tokens
+    }
+
+    const LispToken *token = &g_array_index(tokens, LispToken, *position);
+
+    if (token->type == LISP_TOKEN_TYPE_LIST_START) {
+        // --- Parse a list ---
+        LispAstNode *list_node = g_new0(LispAstNode, 1);
+        list_node->type = LISP_AST_NODE_TYPE_LIST;
+        list_node->start_token = token;
+        list_node->children = g_array_new(FALSE, FALSE, sizeof(LispAstNode*));
+
+        (*position)++; // Consume '('
+
+        while (*position < tokens->len) {
+            const LispToken *current_token = &g_array_index(tokens, LispToken, *position);
+
+            if (current_token->type == LISP_TOKEN_TYPE_LIST_END) {
+                list_node->end_token = current_token;
+                (*position)++; // Consume ')'
+                return list_node;
+            }
+
+            // Skip whitespace and comments inside the list
+            if (current_token->type == LISP_TOKEN_TYPE_WHITESPACE || current_token->type == LISP_TOKEN_TYPE_COMMENT) {
+                (*position)++;
                 continue;
             }
-        }
 
-        LispSyntaxElement *element = lisp_syntax_element_new(current_element_type, token_text, &token_start_iter, &current_iter);
-        g_free(token_text);
-
-        if (!element) {
-            g_warning("Failed to create syntax element for token. Continuing.");
-            continue;
-        }
-
-        GNode *current_parent_node = g_array_index(node_stack, GNode*, node_stack->len - 1);
-        GNode *new_gnode = g_node_new(element);
-        if(!new_gnode){
-            lisp_syntax_element_free(element);
-            g_warning("Failed to create GNode for syntax element. Continuing.");
-            continue;
-        }
-        g_node_append(current_parent_node, new_gnode);
-
-        if (element->type == LISP_SYNTAX_ELEMENT_LIST_START) {
-            g_array_append_val(node_stack, new_gnode); // Push the new list node as current parent
-        } else if (element->type == LISP_SYNTAX_ELEMENT_LIST_END) {
-            if (node_stack->len > 1) { // If stack has more than just the document root
-                GNode *top_node_on_stack = g_array_index(node_stack, GNode*, node_stack->len - 1);
-                LispSyntaxElement *top_node_data = (LispSyntaxElement*) top_node_on_stack->data;
-
-                // The LIST_END's direct parent should be the LIST_START it's closing.
-                // If the top of the stack is that parent (the LIST_START node), then pop it.
-                if (top_node_on_stack == current_parent_node && top_node_data->type == LISP_SYNTAX_ELEMENT_LIST_START) {
-                     g_array_remove_index_fast(node_stack, node_stack->len - 1);
-                } else {
-                    // This ')' does not match the list node on top of stack (current_parent_node).
-                    // Or, current_parent_node is not a LIST_START (e.g. root)
-                    // This means it's an unmatched ')' for the current direct parent.
-                    // The element type of this ')' should be UNMATCHED_CLOSE_PAREN.
-                    // This check is a bit tricky. The `current_parent_node` IS the LIST_START node.
-                    // So if element type is LIST_END, we pop `current_parent_node` from stack.
-                    GNode* just_popped_list_start_node = g_array_index(node_stack, GNode*, node_stack->len-1);
-                    LispSyntaxElement* data_of_list_being_closed = (LispSyntaxElement*)just_popped_list_start_node->data;
-
-                    if (data_of_list_being_closed->type == LISP_SYNTAX_ELEMENT_LIST_START || data_of_list_being_closed->type == LISP_SYNTAX_ELEMENT_INCOMPLETE_LIST) {
-                         g_array_remove_index_fast(node_stack, node_stack->len-1);
-                    } else {
-                        // This indicates an unmatched closing parenthesis.
-                        element->type = LISP_SYNTAX_ELEMENT_UNMATCHED_CLOSE_PAREN;
-                    }
-
-                }
-            } else { // Stack only contains document root, so this ')' is definitely unmatched
-                element->type = LISP_SYNTAX_ELEMENT_UNMATCHED_CLOSE_PAREN;
+            LispAstNode *child_expr = parse_expression(tokens, position, errors);
+            if (child_expr) {
+                g_array_append_val(list_node->children, child_expr);
+            } else {
+                // Error parsing child, or end of tokens inside a list
+                // This means an unmatched open parenthesis.
+                // g_warning("Unmatched open parenthesis.");
+                // TODO: Add to GError list
+                lisp_ast_node_free(list_node); // Clean up the partially formed list node
+                return NULL;
             }
         }
+
+        // If we exit the loop here, the list was not closed.
+        // g_warning("Incomplete list at end of input.");
+        // TODO: Add to GError list
+        lisp_ast_node_free(list_node);
+        return NULL;
+
+    } else if (token->type == LISP_TOKEN_TYPE_ATOM || token->type == LISP_TOKEN_TYPE_STRING) {
+        // --- Parse an atom or string ---
+        LispAstNode *atom_node = g_new0(LispAstNode, 1);
+        atom_node->type = (token->type == LISP_TOKEN_TYPE_STRING) ? LISP_AST_NODE_TYPE_STRING : LISP_AST_NODE_TYPE_ATOM;
+        atom_node->start_token = token;
+        atom_node->end_token = token; // For atoms/strings, start and end are the same.
+        atom_node->children = NULL;
+
+        (*position)++; // Consume the token
+        return atom_node;
+
+    } else if (token->type == LISP_TOKEN_TYPE_LIST_END) {
+        // --- Unmatched closing parenthesis ---
+        // g_warning("Unmatched closing parenthesis.");
+        // TODO: Add to GError list
+        (*position)++; // Consume ')' to allow parsing to potentially continue
+        return NULL;
     }
 
-    // After processing the whole buffer, check the stack for unclosed lists
-    while (node_stack->len > 1) { // Any nodes other than the document root still on stack?
-        GNode *unclosed_node = g_array_index(node_stack, GNode*, node_stack->len - 1);
-        LispSyntaxElement *element_data = (LispSyntaxElement *)unclosed_node->data;
-        if (element_data && element_data->type == LISP_SYNTAX_ELEMENT_LIST_START) {
-            element_data->type = LISP_SYNTAX_ELEMENT_INCOMPLETE_LIST;
-        }
-        // Also handle other potentially stack-managed types if any were introduced
-        g_array_remove_index_fast(node_stack, node_stack->len - 1);
-    }
-
-    g_array_free(node_stack, TRUE);
-    // g_message("LispParser: Parsing complete. AST Root: %p", (void*)parser->ast_root);
+    // Should not be reached if token types are comprehensive
+    (*position)++;
+    return NULL;
 }

--- a/64k/lisp-parser.h
+++ b/64k/lisp-parser.h
@@ -9,28 +9,44 @@ G_BEGIN_DECLS
 // Forward declaration for LispParser
 typedef struct _LispParser LispParser;
 
-// Enum for different types of syntax elements
+// Enum for different types of tokens
 typedef enum {
-    LISP_SYNTAX_ELEMENT_DOCUMENT_ROOT,  // Root of the AST
-    LISP_SYNTAX_ELEMENT_ATOM,           // Symbols, numbers, etc.
-    LISP_SYNTAX_ELEMENT_LIST_START,     // '('
-    LISP_SYNTAX_ELEMENT_LIST_END,       // ')'
-    LISP_SYNTAX_ELEMENT_STRING,         // "a string"
-    LISP_SYNTAX_ELEMENT_COMMENT,        // ; a comment
-    LISP_SYNTAX_ELEMENT_WHITESPACE,
-    LISP_SYNTAX_ELEMENT_INVALID_CHAR,   // A character that doesn't belong
-    LISP_SYNTAX_ELEMENT_UNMATCHED_CLOSE_PAREN, // A ')' without a matching '('
-    LISP_SYNTAX_ELEMENT_INCOMPLETE_LIST, // A list that was started but not closed by EOF
-    LISP_SYNTAX_ELEMENT_INCOMPLETE_STRING // A string that was started but not closed by EOF
-} LispSyntaxElementType;
+    LISP_TOKEN_TYPE_ATOM,
+    LISP_TOKEN_TYPE_LIST_START,     // (
+    LISP_TOKEN_TYPE_LIST_END,       // )
+    LISP_TOKEN_TYPE_STRING,
+    LISP_TOKEN_TYPE_COMMENT,
+    LISP_TOKEN_TYPE_WHITESPACE,
+    LISP_TOKEN_TYPE_INCOMPLETE_STRING,
+    // Note: No 'unmatched close paren' token type; that's a parsing error, not a token type.
+} LispTokenType;
 
-// Structure to hold information about each syntax element
+// Structure for a single token
 typedef struct {
-    LispSyntaxElementType type;
-    gchar *text; // The actual text of the token, owned by this struct
-    GtkTextIter start_iter; // Start position in the GtkTextBuffer
-    GtkTextIter end_iter;   // End position in the GtkTextBuffer
-} LispSyntaxElement;
+    LispTokenType type;
+    gchar *text;
+    GtkTextIter start_iter;
+    GtkTextIter end_iter;
+} LispToken;
+
+// Enum for AST node types
+typedef enum {
+    LISP_AST_NODE_TYPE_ATOM,
+    LISP_AST_NODE_TYPE_LIST,
+    LISP_AST_NODE_TYPE_STRING,
+    // Comments and whitespace are not typically included in the AST
+} LispAstNodeType;
+
+// Forward declaration
+typedef struct _LispAstNode LispAstNode;
+
+// Structure for an AST node
+struct _LispAstNode {
+    LispAstNodeType type;
+    const LispToken *start_token; // For a list, the '('. For an atom, the token itself.
+    const LispToken *end_token;   // For a list, the ')'. For an atom, same as start_token.
+    GArray *children;             // Array of LispAstNode* pointers, for lists only.
+};
 
 // Public API for the LispParser
 
@@ -63,25 +79,27 @@ void lisp_parser_free(LispParser *parser);
 void lisp_parser_parse(LispParser *parser);
 
 /**
- * lisp_parser_get_ast_root:
+ * lisp_parser_get_ast:
  * @parser: The LispParser instance.
  *
- * Gets the root GNode of the Abstract Syntax Tree (AST).
- * The GNode and its children contain LispSyntaxElement data.
- * The returned GNode is owned by the parser and should not be freed by the caller.
- * Its lifetime is tied to the parser or until the next call to `lisp_parser_parse`.
+ * Gets the root node of the Abstract Syntax Tree (AST).
+ * The returned AST is owned by the parser and should not be freed.
+ * Its lifetime is tied to the parser or until the next `lisp_parser_parse`.
  *
- * Returns: (transfer none): The root GNode of the AST.
+ * Returns: (transfer none): The root LispAstNode of the AST, or NULL if parsing failed.
  */
-GNode *lisp_parser_get_ast_root(LispParser *parser);
+const LispAstNode *lisp_parser_get_ast(LispParser *parser);
 
 /**
- * lisp_syntax_element_free:
- * @data: (transfer full): A pointer to a LispSyntaxElement to be freed.
+ * lisp_parser_get_tokens:
+ * @parser: The LispParser instance.
+ * @n_tokens: (out): Pointer to store the number of tokens.
  *
- * Frees the memory allocated for a LispSyntaxElement, including its text.
- * This function is suitable for use with GNode data freeing (e.g., g_node_destroy).
+ * Gets the stream of tokens from the last parse.
+ * The returned array is owned by the parser and should not be freed.
+ *
+ * Returns: (transfer none) (array length=n_tokens): The array of LispToken.
  */
-void lisp_syntax_element_free(gpointer data);
+const LispToken *lisp_parser_get_tokens(LispParser *parser, guint *n_tokens);
 
 G_END_DECLS


### PR DESCRIPTION
…AST.

The previous implementation of the lisp parser used a GTree to represent the AST. I have replaced this with a custom AST structure, which is more efficient and easier to work with. I've also updated the parser to produce a token stream, which can be used for syntax highlighting and other features.

The new implementation is a two-stage process:
1. Tokenization: The input buffer is tokenized into a stream of LispTokens.
2. AST Construction: The token stream is parsed to build the LispAstNode tree.