### PR TITLE
Add Lisp parser tests

### DIFF
--- a/64k/lisp-parser.c
+++ b/64k/lisp-parser.c
@@ -87,7 +87,7 @@ const LispToken *lisp_parser_get_tokens(LispParser *parser, guint *n_tokens) {
     if (n_tokens) {
         *n_tokens = parser->tokens ? parser->tokens->len : 0;
     }
-    return parser->tokens ? (const LispToken*)parser->tokens->pdata : NULL;
+    return parser->tokens ? (const LispToken*)parser->tokens->data : NULL;
 }
 
 void lisp_parser_parse(LispParser *parser) {

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,8 +1,8 @@
 VPATH = ../common
-INCLUDES = -I../common -I../32k
+INCLUDES = -I../common -I../32k -I../64k
 CFLAGS += -Wall $(INCLUDES) `pkg-config --cflags glib-2.0 gobject-2.0 gio-2.0`
 LDLIBS += `pkg-config --libs glib-2.0 gobject-2.0 gio-2.0`
-TESTS = preferences_test process_test swank_process_test swank_session_test
+TESTS = preferences_test process_test swank_process_test swank_session_test lisp_parser_test
 CLEANABLES = $(TESTS)
 
 all: $(TESTS)
@@ -19,11 +19,15 @@ swank_process_test: swank_process_test.c ../32k/swank_process.c ../32k/real_swan
 swank_session_test: swank_session_test.c ../32k/swank_session.c ../32k/swank_process.c ../32k/real_swank_session.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
+lisp_parser_test: lisp_parser_test.c ../64k/lisp-parser.c
+	$(CC) $(CFLAGS) `pkg-config --cflags gtk+-3.0 gtksourceview-4` $^ -o $@ $(LDLIBS) `pkg-config --libs gtk+-3.0 gtksourceview-4`
+
 run: all
 	./preferences_test
 	./process_test
 	./swank_process_test
 	./swank_session_test
+	./lisp_parser_test
 
 clean:
 	rm -f $(CLEANABLES)

--- a/tests/lisp_parser_test.c
+++ b/tests/lisp_parser_test.c
@@ -1,0 +1,108 @@
+#include "lisp-parser.h"
+#include <glib.h>
+#include <gtk/gtk.h>
+#include <gtksourceview/gtksource.h>
+
+static LispParser *parser_from_text(const gchar *text)
+{
+  GtkSourceBuffer *buffer = gtk_source_buffer_new(NULL);
+  gtk_text_buffer_set_text(GTK_TEXT_BUFFER(buffer), text, -1);
+  LispParser *parser = lisp_parser_new(buffer);
+  lisp_parser_parse(parser);
+  g_object_unref(buffer);
+  return parser;
+}
+
+static void test_empty_file(void)
+{
+  LispParser *parser = parser_from_text("");
+  guint n_tokens = 0;
+  const LispToken *tokens = lisp_parser_get_tokens(parser, &n_tokens);
+  g_assert_cmpint(n_tokens, ==, 0);
+  const LispAstNode *ast = lisp_parser_get_ast(parser);
+  g_assert_cmpint(ast->children->len, ==, 0);
+  lisp_parser_free(parser);
+}
+
+static void test_atom_symbol(void)
+{
+  LispParser *parser = parser_from_text("foo");
+  guint n_tokens = 0;
+  const LispToken *tokens = lisp_parser_get_tokens(parser, &n_tokens);
+  g_assert_cmpint(n_tokens, ==, 1);
+  g_assert_cmpint(tokens[0].type, ==, LISP_TOKEN_TYPE_ATOM);
+  const LispAstNode *ast = lisp_parser_get_ast(parser);
+  g_assert_cmpint(ast->children->len, ==, 1);
+  const LispAstNode *child = g_array_index(ast->children, LispAstNode*, 0);
+  g_assert_cmpint(child->type, ==, LISP_AST_NODE_TYPE_ATOM);
+  g_assert_cmpstr(child->start_token->text, ==, "foo");
+  lisp_parser_free(parser);
+}
+
+static void test_atom_string(void)
+{
+  LispParser *parser = parser_from_text("\"bar\"");
+  guint n_tokens = 0;
+  const LispToken *tokens = lisp_parser_get_tokens(parser, &n_tokens);
+  g_assert_cmpint(n_tokens, ==, 1);
+  g_assert_cmpint(tokens[0].type, ==, LISP_TOKEN_TYPE_STRING);
+  const LispAstNode *ast = lisp_parser_get_ast(parser);
+  g_assert_cmpint(ast->children->len, ==, 1);
+  const LispAstNode *child = g_array_index(ast->children, LispAstNode*, 0);
+  g_assert_cmpint(child->type, ==, LISP_AST_NODE_TYPE_STRING);
+  g_assert_cmpstr(child->start_token->text, ==, "\"bar\"");
+  lisp_parser_free(parser);
+}
+
+static void test_empty_list(void)
+{
+  LispParser *parser = parser_from_text("()");
+  const LispAstNode *ast = lisp_parser_get_ast(parser);
+  g_assert_cmpint(ast->children->len, ==, 1);
+  const LispAstNode *child = g_array_index(ast->children, LispAstNode*, 0);
+  g_assert_cmpint(child->type, ==, LISP_AST_NODE_TYPE_LIST);
+  g_assert_cmpint(child->children->len, ==, 0);
+  lisp_parser_free(parser);
+}
+
+static void test_list_with_elements(void)
+{
+  LispParser *parser = parser_from_text("(a b)");
+  const LispAstNode *ast = lisp_parser_get_ast(parser);
+  g_assert_cmpint(ast->children->len, ==, 1);
+  const LispAstNode *list = g_array_index(ast->children, LispAstNode*, 0);
+  g_assert_cmpint(list->type, ==, LISP_AST_NODE_TYPE_LIST);
+  g_assert_cmpint(list->children->len, ==, 2);
+  const LispAstNode *a = g_array_index(list->children, LispAstNode*, 0);
+  const LispAstNode *b = g_array_index(list->children, LispAstNode*, 1);
+  g_assert_cmpint(a->type, ==, LISP_AST_NODE_TYPE_ATOM);
+  g_assert_cmpstr(a->start_token->text, ==, "a");
+  g_assert_cmpint(b->type, ==, LISP_AST_NODE_TYPE_ATOM);
+  g_assert_cmpstr(b->start_token->text, ==, "b");
+  lisp_parser_free(parser);
+}
+
+static void test_extra_closing_paren(void)
+{
+  LispParser *parser = parser_from_text(")");
+  guint n_tokens = 0;
+  lisp_parser_get_tokens(parser, &n_tokens);
+  const LispAstNode *ast = lisp_parser_get_ast(parser);
+  g_assert_cmpint(n_tokens, ==, 1);
+  g_assert_cmpint(ast->children->len, ==, 0);
+  lisp_parser_free(parser);
+}
+
+int main(int argc, char *argv[])
+{
+  g_test_init(&argc, &argv, NULL);
+  gtk_init_check(&argc, &argv);
+  g_test_add_func("/lisp_parser/empty_file", test_empty_file);
+  g_test_add_func("/lisp_parser/atom_symbol", test_atom_symbol);
+  g_test_add_func("/lisp_parser/atom_string", test_atom_string);
+  g_test_add_func("/lisp_parser/empty_list", test_empty_list);
+  g_test_add_func("/lisp_parser/list_with_elements", test_list_with_elements);
+  g_test_add_func("/lisp_parser/extra_closing_paren", test_extra_closing_paren);
+  return g_test_run();
+}
+


### PR DESCRIPTION
## Summary
- add unit tests for the Lisp parser
- fix tokens pointer field
- build new tests in Makefile

## Testing
- `make -C tests lisp_parser_test`
- `./tests/lisp_parser_test`

------
https://chatgpt.com/codex/tasks/task_e_68734e046e308328aca205d06cac6d72