### PR TITLE
Add Lisp parser tree view and Alt+P shortcut

### DIFF
--- a/64k/Makefile
+++ b/64k/Makefile
@@ -1,6 +1,6 @@
 
 LIBS += gtksourceview-4
-SOURCES += file_open.c file_save.c preferences.c preferences_dialog.c find_executables.c process.c real_process.c swank_process.c real_swank_process.c real_swank_session.c swank_session.c evaluate.c interactions_view.c app.c lisp_source_view.c lisp-parser.c
+SOURCES += file_open.c file_save.c preferences.c preferences_dialog.c find_executables.c process.c real_process.c swank_process.c real_swank_process.c real_swank_session.c swank_session.c evaluate.c interactions_view.c app.c lisp_source_view.c lisp-parser.c lisp_parser_view.c
 
 include ../common/common.mk
 

--- a/64k/app.c
+++ b/64k/app.c
@@ -6,6 +6,7 @@
 #include "evaluate.h"
 #include "interactions_view.h"
 #include "lisp_source_view.h"
+#include "lisp_parser_view.h"
 
 /* Signal handlers */
 STATIC gboolean quit_delete_event (GtkWidget * /*widget*/, GdkEvent * /*event*/, gpointer data);
@@ -24,6 +25,15 @@ struct _App
   SwankSession   *swank;
 };
 
+static void
+on_show_parser(App *self)
+{
+  GtkWidget *win = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+  GtkWidget *view = lisp_parser_view_new(self->buffer);
+  gtk_container_add(GTK_CONTAINER(win), view);
+  gtk_widget_show_all(win);
+}
+
 static gboolean
 on_key_press(GtkWidget * /*widget*/,
     GdkEventKey *event,
@@ -36,6 +46,12 @@ on_key_press(GtkWidget * /*widget*/,
   {
     on_evaluate(self);
     return TRUE;                  /* stop further propagation */
+  }
+  if ((event->keyval == GDK_KEY_p || event->keyval == GDK_KEY_P) &&
+      (event->state & GDK_MOD1_MASK))        /* Alt+P */
+  {
+    on_show_parser(self);
+    return TRUE;
   }
   return FALSE;
 }

--- a/64k/lisp_parser_view.c
+++ b/64k/lisp_parser_view.c
@@ -1,0 +1,128 @@
+#include "lisp_parser_view.h"
+
+struct _LispParserView
+{
+  GtkTreeView parent_instance;
+  GtkSourceBuffer *buffer;
+  LispParser *parser;
+  GtkTreeStore *store;
+};
+
+G_DEFINE_TYPE(LispParserView, lisp_parser_view, GTK_TYPE_TREE_VIEW)
+
+enum { COL_TYPE, COL_TEXT, N_COLS };
+
+static void populate_store(LispParserView *self);
+static void parser_view_buffer_changed(GtkTextBuffer * /*buffer*/, gpointer data);
+
+static void
+lisp_parser_view_init(LispParserView *self)
+{
+  GtkCellRenderer *renderer;
+
+  self->buffer = NULL;
+  self->parser = NULL;
+  self->store = gtk_tree_store_new(N_COLS, G_TYPE_STRING, G_TYPE_STRING);
+
+  gtk_tree_view_set_model(GTK_TREE_VIEW(self), GTK_TREE_MODEL(self->store));
+
+  renderer = gtk_cell_renderer_text_new();
+  gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(self), -1, "Type",
+      renderer, "text", COL_TYPE, NULL);
+
+  renderer = gtk_cell_renderer_text_new();
+  gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(self), -1, "Text",
+      renderer, "text", COL_TEXT, NULL);
+}
+
+static void
+lisp_parser_view_dispose(GObject *object)
+{
+  LispParserView *self = LISP_PARSER_VIEW(object);
+
+  if (self->parser)
+  {
+    lisp_parser_free(self->parser);
+    self->parser = NULL;
+  }
+
+  g_clear_object(&self->buffer);
+  g_clear_object(&self->store);
+
+  G_OBJECT_CLASS(lisp_parser_view_parent_class)->dispose(object);
+}
+
+static void
+lisp_parser_view_class_init(LispParserViewClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS(klass);
+  object_class->dispose = lisp_parser_view_dispose;
+}
+
+static const gchar *
+node_type_to_string(LispAstNodeType type)
+{
+  switch(type)
+  {
+    case LISP_AST_NODE_TYPE_ATOM: return "Atom";
+    case LISP_AST_NODE_TYPE_LIST: return "List";
+    case LISP_AST_NODE_TYPE_STRING: return "String";
+    default: return "Unknown";
+  }
+}
+
+static void
+add_ast_node(LispParserView *self, const LispAstNode *node, GtkTreeIter *parent)
+{
+  GtkTreeIter iter;
+  const gchar *type = node_type_to_string(node->type);
+  const gchar *text = node->start_token ? node->start_token->text : "";
+
+  gtk_tree_store_append(self->store, &iter, parent);
+  gtk_tree_store_set(self->store, &iter,
+      COL_TYPE, type,
+      COL_TEXT, text,
+      -1);
+
+  if (node->children)
+  {
+    for (guint i = 0; i < node->children->len; i++)
+    {
+      LispAstNode *child = g_array_index(node->children, LispAstNode*, i);
+      add_ast_node(self, child, &iter);
+    }
+  }
+}
+
+static void
+populate_store(LispParserView *self)
+{
+  if (!self->parser)
+    return;
+
+  gtk_tree_store_clear(self->store);
+  lisp_parser_parse(self->parser);
+
+  const LispAstNode *ast = lisp_parser_get_ast(self->parser);
+  if (ast)
+    add_ast_node(self, ast, NULL);
+}
+
+static void
+parser_view_buffer_changed(GtkTextBuffer * /*buffer*/, gpointer data)
+{
+  LispParserView *self = LISP_PARSER_VIEW(data);
+  populate_store(self);
+}
+
+GtkWidget *
+lisp_parser_view_new(GtkSourceBuffer *buffer)
+{
+  LispParserView *self = g_object_new(LISP_TYPE_PARSER_VIEW, NULL);
+  self->buffer = g_object_ref(buffer);
+  self->parser = lisp_parser_new(buffer);
+  populate_store(self);
+  g_signal_connect(self->buffer, "changed", G_CALLBACK(parser_view_buffer_changed), self);
+  return GTK_WIDGET(self);
+}
+

--- a/64k/lisp_parser_view.h
+++ b/64k/lisp_parser_view.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "lisp-parser.h"
+
+G_BEGIN_DECLS
+
+#define LISP_TYPE_PARSER_VIEW (lisp_parser_view_get_type())
+G_DECLARE_FINAL_TYPE(LispParserView, lisp_parser_view, LISP, PARSER_VIEW, GtkTreeView)
+
+GtkWidget *lisp_parser_view_new(GtkSourceBuffer *buffer);
+
+G_END_DECLS

--- a/64k/main.c
+++ b/64k/main.c
@@ -9,6 +9,7 @@
 #include "interactions_view.c"
 #include "lisp-parser.c"
 #include "lisp_source_view.c"
+#include "lisp_parser_view.c"
 #include "preferences.c"
 #include "preferences_dialog.c"
 #include "process.c"


### PR DESCRIPTION
## Summary
- visualize Lisp parser output with `LispParserView`
- show the parser window on Alt+P
- compile new component as part of 64k build

## Testing
- `make -C 64k`
- `make -C tests run` *(fails: No rule to make target '../32k/process.c')*

------
https://chatgpt.com/codex/tasks/task_e_6874c26399348328bd96d6910ae787dc