### PR TITLE
Fix buffer signal leak in views

### DIFF
--- a/64k/lisp_parser_view.c
+++ b/64k/lisp_parser_view.c
@@ -46,6 +46,9 @@ lisp_parser_view_dispose(GObject *object)
     self->parser = NULL;
   }
 
+  if (self->buffer)
+    g_signal_handlers_disconnect_by_data(self->buffer, self);
+
   g_clear_object(&self->buffer);
   g_clear_object(&self->store);
 

--- a/64k/lisp_source_view.c
+++ b/64k/lisp_source_view.c
@@ -59,6 +59,9 @@ lisp_source_view_dispose (GObject *object)
     self->parser = NULL;
   }
 
+  if (self->buffer)
+    g_signal_handlers_disconnect_by_data (self->buffer, self);
+
   // Buffer is a GObject, gtk_text_view_set_buffer increments its ref count.
   // It will be unref'd when GtkTextView is disposed, or we can g_clear_object it.
   // The original code used g_clear_object, which is fine.


### PR DESCRIPTION
## Summary
- disconnect buffer signal handlers in `LispParserView` and `LispSourceView`

## Testing
- `make -C 64k`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687520d2c3c88328a0bea539f1fe54b3