### PR TITLE
Decouple LispParser from Gtk

### DIFF
--- a/64k/Makefile
+++ b/64k/Makefile
@@ -1,6 +1,6 @@
 
 LIBS += gtksourceview-4
-SOURCES += file_open.c file_save.c preferences.c preferences_dialog.c find_executables.c process.c real_process.c swank_process.c real_swank_process.c real_swank_session.c swank_session.c evaluate.c interactions_view.c app.c lisp_source_view.c lisp_parser.c lisp_parser_view.c
+SOURCES += file_open.c file_save.c preferences.c preferences_dialog.c find_executables.c process.c real_process.c swank_process.c real_swank_process.c real_swank_session.c swank_session.c evaluate.c interactions_view.c app.c lisp_source_view.c lisp_parser.c lisp_parser_view.c gtk_text_provider.c string_text_provider.c text_provider.c
 
 include ../common/common.mk
 

--- a/64k/gtk_text_provider.c
+++ b/64k/gtk_text_provider.c
@@ -1,0 +1,81 @@
+#include "gtk_text_provider.h"
+
+struct _GtkTextProvider {
+  GObject parent_instance;
+  GtkTextBuffer *buffer;
+};
+
+static gsize gtk_tp_get_length(TextProvider *self);
+static gunichar gtk_tp_get_char(TextProvider *self, gsize offset);
+static gsize gtk_tp_next_offset(TextProvider *self, gsize offset);
+static gchar *gtk_tp_get_text(TextProvider *self, gsize start, gsize end);
+
+static void gtk_text_provider_text_provider_iface_init(TextProviderInterface *iface) {
+  iface->get_length = gtk_tp_get_length;
+  iface->get_char = gtk_tp_get_char;
+  iface->next_offset = gtk_tp_next_offset;
+  iface->get_text = gtk_tp_get_text;
+}
+
+G_DEFINE_TYPE_WITH_CODE(GtkTextProvider, gtk_text_provider, G_TYPE_OBJECT,
+    G_IMPLEMENT_INTERFACE(TEXT_PROVIDER_TYPE, gtk_text_provider_text_provider_iface_init))
+
+static void gtk_text_provider_init(GtkTextProvider *self) {
+  self->buffer = NULL;
+}
+
+static void gtk_text_provider_finalize(GObject *object) {
+  GtkTextProvider *self = GLIDE_GTK_TEXT_PROVIDER(object);
+  if (self->buffer)
+    g_object_unref(self->buffer);
+  G_OBJECT_CLASS(gtk_text_provider_parent_class)->finalize(object);
+}
+
+static void gtk_text_provider_class_init(GtkTextProviderClass *klass) {
+  GObjectClass *obj = G_OBJECT_CLASS(klass);
+  obj->finalize = gtk_text_provider_finalize;
+}
+
+TextProvider *gtk_text_provider_new(GtkTextBuffer *buffer) {
+  GtkTextProvider *self = g_object_new(GTK_TEXT_PROVIDER_TYPE, NULL);
+  self->buffer = g_object_ref(buffer);
+  return GLIDE_TEXT_PROVIDER(self);
+}
+
+GtkTextBuffer *gtk_text_provider_get_buffer(GtkTextProvider *self) {
+  g_return_val_if_fail(GLIDE_IS_GTK_TEXT_PROVIDER(self), NULL);
+  return self->buffer;
+}
+
+static gsize gtk_tp_get_length(TextProvider *self) {
+  GtkTextProvider *tp = GLIDE_GTK_TEXT_PROVIDER(self);
+  GtkTextIter start, end;
+  gtk_text_buffer_get_bounds(tp->buffer, &start, &end);
+  return gtk_text_iter_get_offset(&end);
+}
+
+static gunichar gtk_tp_get_char(TextProvider *self, gsize offset) {
+  GtkTextProvider *tp = GLIDE_GTK_TEXT_PROVIDER(self);
+  GtkTextIter iter;
+  gtk_text_buffer_get_iter_at_offset(tp->buffer, &iter, (gint)offset);
+  return gtk_text_iter_get_char(&iter);
+}
+
+static gsize gtk_tp_next_offset(TextProvider *self, gsize offset) {
+  GtkTextProvider *tp = GLIDE_GTK_TEXT_PROVIDER(self);
+  GtkTextIter iter;
+  gtk_text_buffer_get_iter_at_offset(tp->buffer, &iter, (gint)offset);
+  if (gtk_text_iter_is_end(&iter))
+    return offset;
+  gtk_text_iter_forward_char(&iter);
+  return (gsize)gtk_text_iter_get_offset(&iter);
+}
+
+static gchar *gtk_tp_get_text(TextProvider *self, gsize start, gsize end) {
+  GtkTextProvider *tp = GLIDE_GTK_TEXT_PROVIDER(self);
+  GtkTextIter s, e;
+  gtk_text_buffer_get_iter_at_offset(tp->buffer, &s, (gint)start);
+  gtk_text_buffer_get_iter_at_offset(tp->buffer, &e, (gint)end);
+  return gtk_text_iter_get_text(&s, &e);
+}
+

--- a/64k/gtk_text_provider.h
+++ b/64k/gtk_text_provider.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "text_provider.h"
+#include <gtk/gtk.h>
+#include <gtksourceview/gtksource.h>
+
+#define GTK_TEXT_PROVIDER_TYPE (gtk_text_provider_get_type())
+G_DECLARE_FINAL_TYPE(GtkTextProvider, gtk_text_provider, GLIDE, GTK_TEXT_PROVIDER, GObject)
+
+TextProvider *gtk_text_provider_new(GtkTextBuffer *buffer);
+GtkTextBuffer *gtk_text_provider_get_buffer(GtkTextProvider *self);
+

--- a/64k/lisp_parser.c
+++ b/64k/lisp_parser.c
@@ -1,11 +1,10 @@
 // Ensure all dependency headers are processed before our own header.
 #include <glib.h>
-#include <gtk/gtk.h>
 #include "lisp_parser.h"
 
 // Define the LispParser structure
 struct _LispParser {
-    GtkSourceBuffer *buffer; // Not owned
+    TextProvider *provider; // Not owned
     GArray *tokens;          // Owns LispToken structs
     LispAstNode *ast;        // Owns the AST
 };
@@ -52,12 +51,11 @@ static void lisp_parser_clear_data(LispParser *parser) {
 
 // --- LispParser Implementation ---
 
-LispParser *lisp_parser_new(GtkSourceBuffer *buffer) {
-    g_return_val_if_fail(GTK_SOURCE_IS_BUFFER(buffer), NULL);
+LispParser *lisp_parser_new(TextProvider *provider) {
+    g_return_val_if_fail(GLIDE_IS_TEXT_PROVIDER(provider), NULL);
 
     LispParser *parser = g_new0(LispParser, 1);
-    parser->buffer = buffer;
-    // Other fields are initialized to NULL by g_new0
+    parser->provider = provider;
 
     return parser;
 }
@@ -83,7 +81,7 @@ const LispToken *lisp_parser_get_tokens(LispParser *parser, guint *n_tokens) {
 
 void lisp_parser_parse(LispParser *parser) {
     g_return_if_fail(parser != NULL);
-    g_return_if_fail(GTK_SOURCE_IS_BUFFER(parser->buffer));
+    g_return_if_fail(GLIDE_IS_TEXT_PROVIDER(parser->provider));
 
     // 1. Clear previous results
     lisp_parser_clear_data(parser);
@@ -93,74 +91,73 @@ void lisp_parser_parse(LispParser *parser) {
     g_array_set_clear_func(parser->tokens, lisp_token_free);
 
     // 2. Tokenization Stage
-    GtkTextIter current_iter;
-    gtk_text_buffer_get_start_iter(GTK_TEXT_BUFFER(parser->buffer), &current_iter);
+    gsize len = text_provider_get_length(parser->provider);
+    gsize offset = 0;
 
-    while (!gtk_text_iter_is_end(&current_iter)) {
-        gunichar current_char = gtk_text_iter_get_char(&current_iter);
+    while (offset < len) {
+        gunichar current_char = text_provider_get_char(parser->provider, offset);
         LispToken token = {0};
-        token.start_iter = current_iter;
+        token.start_offset = offset;
 
         if (g_unichar_isspace(current_char)) {
             token.type = LISP_TOKEN_TYPE_WHITESPACE;
-            GtkTextIter end_iter = current_iter;
-            while (!gtk_text_iter_is_end(&end_iter) && g_unichar_isspace(gtk_text_iter_get_char(&end_iter))) {
-                gtk_text_iter_forward_char(&end_iter);
+            gsize end = offset;
+            while (end < len && g_unichar_isspace(text_provider_get_char(parser->provider, end))) {
+                end = text_provider_next_offset(parser->provider, end);
             }
-            token.end_iter = end_iter;
-            current_iter = end_iter;
+            token.end_offset = end;
+            offset = end;
         } else if (current_char == ';') {
             token.type = LISP_TOKEN_TYPE_COMMENT;
-            GtkTextIter end_iter = current_iter;
-            while (!gtk_text_iter_is_end(&end_iter) && gtk_text_iter_get_char(&end_iter) != '\n') {
-                gtk_text_iter_forward_char(&end_iter);
+            gsize end = offset;
+            while (end < len && text_provider_get_char(parser->provider, end) != '\n') {
+                end = text_provider_next_offset(parser->provider, end);
             }
-            token.end_iter = end_iter;
-            current_iter = end_iter;
+            token.end_offset = end;
+            offset = end;
         } else if (current_char == '(') {
             token.type = LISP_TOKEN_TYPE_LIST_START;
-            gtk_text_iter_forward_char(&current_iter);
-            token.end_iter = current_iter;
+            offset = text_provider_next_offset(parser->provider, offset);
+            token.end_offset = offset;
         } else if (current_char == ')') {
             token.type = LISP_TOKEN_TYPE_LIST_END;
-            gtk_text_iter_forward_char(&current_iter);
-            token.end_iter = current_iter;
+            offset = text_provider_next_offset(parser->provider, offset);
+            token.end_offset = offset;
         } else if (current_char == '"') {
-            GtkTextIter end_iter = current_iter;
-            gtk_text_iter_forward_char(&end_iter); // Skip opening quote
+            gsize end = text_provider_next_offset(parser->provider, offset); /* skip opening quote */
             gboolean escaped = FALSE;
             gboolean found_end = FALSE;
-            while (!gtk_text_iter_is_end(&end_iter)) {
-                gunichar c = gtk_text_iter_get_char(&end_iter);
+            while (end < len) {
+                gunichar c = text_provider_get_char(parser->provider, end);
                 if (escaped) {
                     escaped = FALSE;
                 } else if (c == '\\') {
                     escaped = TRUE;
                 } else if (c == '"') {
                     found_end = TRUE;
-                    gtk_text_iter_forward_char(&end_iter);
+                    end = text_provider_next_offset(parser->provider, end);
                     break;
                 }
-                gtk_text_iter_forward_char(&end_iter);
+                end = text_provider_next_offset(parser->provider, end);
             }
             token.type = found_end ? LISP_TOKEN_TYPE_STRING : LISP_TOKEN_TYPE_INCOMPLETE_STRING;
-            token.end_iter = end_iter;
-            current_iter = end_iter;
-        } else { // Atom
+            token.end_offset = end;
+            offset = end;
+        } else { /* Atom */
             token.type = LISP_TOKEN_TYPE_ATOM;
-            GtkTextIter end_iter = current_iter;
-            while (!gtk_text_iter_is_end(&end_iter)) {
-                gunichar c = gtk_text_iter_get_char(&end_iter);
+            gsize end = offset;
+            while (end < len) {
+                gunichar c = text_provider_get_char(parser->provider, end);
                 if (g_unichar_isspace(c) || c == '(' || c == ')' || c == '"' || c == ';') {
                     break;
                 }
-                gtk_text_iter_forward_char(&end_iter);
+                end = text_provider_next_offset(parser->provider, end);
             }
-            token.end_iter = end_iter;
-            current_iter = end_iter;
+            token.end_offset = end;
+            offset = end;
         }
 
-        token.text = gtk_text_iter_get_text(&token.start_iter, &token.end_iter);
+        token.text = text_provider_get_text(parser->provider, token.start_offset, token.end_offset);
         g_array_append_val(parser->tokens, token);
     }
 

--- a/64k/lisp_parser.h
+++ b/64k/lisp_parser.h
@@ -1,8 +1,7 @@
 #pragma once
 
 #include <glib.h>
-#include <gtk/gtk.h>
-#include <gtksourceview/gtksource.h> // For GtkSourceBuffer
+#include "text_provider.h"
 
 G_BEGIN_DECLS
 
@@ -25,8 +24,8 @@ typedef enum {
 typedef struct {
     LispTokenType type;
     gchar *text;
-    GtkTextIter start_iter;
-    GtkTextIter end_iter;
+    gsize start_offset;
+    gsize end_offset;
 } LispToken;
 
 // Enum for AST node types
@@ -52,14 +51,14 @@ struct _LispAstNode {
 
 /**
  * lisp_parser_new:
- * @buffer: The GtkSourceBuffer to parse.
+ * @provider: The TextProvider to parse.
  *
- * Creates a new LispParser instance for the given buffer.
- * The parser does not take ownership of the buffer.
+ * Creates a new LispParser instance for the given provider.
+ * The parser does not take ownership of the provider.
  *
  * Returns: (transfer full): A new LispParser instance.
  */
-LispParser *lisp_parser_new(GtkSourceBuffer *buffer);
+LispParser *lisp_parser_new(TextProvider *provider);
 
 /**
  * lisp_parser_free:
@@ -73,7 +72,7 @@ void lisp_parser_free(LispParser *parser);
  * lisp_parser_parse:
  * @parser: The LispParser instance.
  *
- * Parses or re-parses the content of the GtkSourceBuffer associated with the parser.
+ * Parses or re-parses the content provided by the TextProvider associated with the parser.
  * The existing AST in the parser is destroyed and a new one is built.
  */
 void lisp_parser_parse(LispParser *parser);

--- a/64k/lisp_parser_view.c
+++ b/64k/lisp_parser_view.c
@@ -1,9 +1,11 @@
 #include "lisp_parser_view.h"
+#include "gtk_text_provider.h"
 
 struct _LispParserView
 {
   GtkTreeView parent_instance;
   GtkSourceBuffer *buffer;
+  TextProvider *provider;
   LispParser *parser;
   GtkTreeStore *store;
 };
@@ -45,6 +47,8 @@ lisp_parser_view_dispose(GObject *object)
     lisp_parser_free(self->parser);
     self->parser = NULL;
   }
+
+  g_clear_object(&self->provider);
 
   if (self->buffer)
     g_signal_handlers_disconnect_by_data(self->buffer, self);
@@ -132,7 +136,8 @@ lisp_parser_view_new(GtkSourceBuffer *buffer)
 {
   LispParserView *self = g_object_new(LISP_TYPE_PARSER_VIEW, NULL);
   self->buffer = g_object_ref(buffer);
-  self->parser = lisp_parser_new(buffer);
+  self->provider = gtk_text_provider_new(GTK_TEXT_BUFFER(buffer));
+  self->parser = lisp_parser_new(self->provider);
   populate_store(self);
   g_signal_connect(self->buffer, "changed", G_CALLBACK(parser_view_buffer_changed), self);
   return GTK_WIDGET(self);

--- a/64k/lisp_parser_view.h
+++ b/64k/lisp_parser_view.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "lisp_parser.h"
+#include <gtk/gtk.h>
+#include <gtksourceview/gtksource.h>
 
 G_BEGIN_DECLS
 

--- a/64k/lisp_source_view.c
+++ b/64k/lisp_source_view.c
@@ -1,10 +1,12 @@
 #include "lisp_source_view.h"
+#include "gtk_text_provider.h"
 
 struct _LispSourceView
 {
   GtkSourceView parent_instance;
 
   GtkSourceBuffer *buffer;
+  TextProvider *provider;
   LispParser *parser; // Add the parser instance
 };
 
@@ -23,7 +25,8 @@ lisp_source_view_init (LispSourceView *self)
   gtk_source_view_set_show_line_numbers (GTK_SOURCE_VIEW (self), TRUE);
 
   // Initialize the LispParser
-  self->parser = lisp_parser_new(self->buffer);
+  self->provider = gtk_text_provider_new(GTK_TEXT_BUFFER(self->buffer));
+  self->parser = lisp_parser_new(self->provider);
   if (self->parser) {
     lisp_parser_parse(self->parser); // Perform an initial parse
   } else {
@@ -58,6 +61,8 @@ lisp_source_view_dispose (GObject *object)
     lisp_parser_free(self->parser);
     self->parser = NULL;
   }
+
+  g_clear_object(&self->provider);
 
   if (self->buffer)
     g_signal_handlers_disconnect_by_data (self->buffer, self);

--- a/64k/lisp_source_view.h
+++ b/64k/lisp_source_view.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "lisp_parser.h"
+#include <gtk/gtk.h>
+#include <gtksourceview/gtksource.h>
 
 G_BEGIN_DECLS
 

--- a/64k/string_text_provider.c
+++ b/64k/string_text_provider.c
@@ -1,0 +1,71 @@
+#include "string_text_provider.h"
+
+struct _StringTextProvider {
+  GObject parent_instance;
+  gchar *text;
+};
+
+static gsize stp_get_length(TextProvider *self);
+static gunichar stp_get_char(TextProvider *self, gsize offset);
+static gsize stp_next_offset(TextProvider *self, gsize offset);
+static gchar *stp_get_text(TextProvider *self, gsize start, gsize end);
+
+static void string_text_provider_text_provider_iface_init(TextProviderInterface *iface) {
+  iface->get_length = stp_get_length;
+  iface->get_char = stp_get_char;
+  iface->next_offset = stp_next_offset;
+  iface->get_text = stp_get_text;
+}
+
+G_DEFINE_TYPE_WITH_CODE(StringTextProvider, string_text_provider, G_TYPE_OBJECT,
+    G_IMPLEMENT_INTERFACE(TEXT_PROVIDER_TYPE, string_text_provider_text_provider_iface_init))
+
+static void string_text_provider_init(StringTextProvider *self) {
+  self->text = NULL;
+}
+
+static void string_text_provider_finalize(GObject *object) {
+  StringTextProvider *self = GLIDE_STRING_TEXT_PROVIDER(object);
+  g_free(self->text);
+  G_OBJECT_CLASS(string_text_provider_parent_class)->finalize(object);
+}
+
+static void string_text_provider_class_init(StringTextProviderClass *klass) {
+  GObjectClass *obj = G_OBJECT_CLASS(klass);
+  obj->finalize = string_text_provider_finalize;
+}
+
+TextProvider *string_text_provider_new(const gchar *text) {
+  StringTextProvider *self = g_object_new(STRING_TEXT_PROVIDER_TYPE, NULL);
+  self->text = g_strdup(text);
+  return GLIDE_TEXT_PROVIDER(self);
+}
+
+const gchar *string_text_provider_get_text_ref(StringTextProvider *self) {
+  g_return_val_if_fail(GLIDE_IS_STRING_TEXT_PROVIDER(self), NULL);
+  return self->text;
+}
+
+static gsize stp_get_length(TextProvider *self) {
+  StringTextProvider *tp = GLIDE_STRING_TEXT_PROVIDER(self);
+  return strlen(tp->text);
+}
+
+static gunichar stp_get_char(TextProvider *self, gsize offset) {
+  StringTextProvider *tp = GLIDE_STRING_TEXT_PROVIDER(self);
+  const gchar *p = tp->text + offset;
+  return g_utf8_get_char(p);
+}
+
+static gsize stp_next_offset(TextProvider *self, gsize offset) {
+  StringTextProvider *tp = GLIDE_STRING_TEXT_PROVIDER(self);
+  const gchar *p = tp->text + offset;
+  const gchar *n = g_utf8_next_char(p);
+  return (gsize)(n - tp->text);
+}
+
+static gchar *stp_get_text(TextProvider *self, gsize start, gsize end) {
+  StringTextProvider *tp = GLIDE_STRING_TEXT_PROVIDER(self);
+  return g_strndup(tp->text + start, end - start);
+}
+

--- a/64k/string_text_provider.h
+++ b/64k/string_text_provider.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "text_provider.h"
+
+#define STRING_TEXT_PROVIDER_TYPE (string_text_provider_get_type())
+G_DECLARE_FINAL_TYPE(StringTextProvider, string_text_provider, GLIDE, STRING_TEXT_PROVIDER, GObject)
+
+TextProvider *string_text_provider_new(const gchar *text);
+const gchar *string_text_provider_get_text_ref(StringTextProvider *self);
+

--- a/64k/text_provider.c
+++ b/64k/text_provider.c
@@ -1,0 +1,5 @@
+#include "text_provider.h"
+
+static void text_provider_default_init(TextProviderInterface *iface) {}
+
+G_DEFINE_INTERFACE(TextProvider, text_provider, G_TYPE_OBJECT)

--- a/64k/text_provider.h
+++ b/64k/text_provider.h
@@ -1,0 +1,37 @@
+#ifndef TEXT_PROVIDER_H
+#define TEXT_PROVIDER_H
+
+#include <glib-object.h>
+
+#define TEXT_PROVIDER_TYPE (text_provider_get_type())
+G_DECLARE_INTERFACE(TextProvider, text_provider, GLIDE, TEXT_PROVIDER, GObject)
+
+struct _TextProviderInterface {
+  GTypeInterface parent_iface;
+  gsize   (*get_length)(TextProvider *self);
+  gunichar (*get_char)(TextProvider *self, gsize offset);
+  gsize   (*next_offset)(TextProvider *self, gsize offset);
+  gchar  *(*get_text)(TextProvider *self, gsize start, gsize end);
+};
+
+static inline gsize text_provider_get_length(TextProvider *self) {
+  g_return_val_if_fail(GLIDE_IS_TEXT_PROVIDER(self), 0);
+  return GLIDE_TEXT_PROVIDER_GET_IFACE(self)->get_length(self);
+}
+
+static inline gunichar text_provider_get_char(TextProvider *self, gsize offset) {
+  g_return_val_if_fail(GLIDE_IS_TEXT_PROVIDER(self), 0);
+  return GLIDE_TEXT_PROVIDER_GET_IFACE(self)->get_char(self, offset);
+}
+
+static inline gsize text_provider_next_offset(TextProvider *self, gsize offset) {
+  g_return_val_if_fail(GLIDE_IS_TEXT_PROVIDER(self), offset);
+  return GLIDE_TEXT_PROVIDER_GET_IFACE(self)->next_offset(self, offset);
+}
+
+static inline gchar *text_provider_get_text(TextProvider *self, gsize start, gsize end) {
+  g_return_val_if_fail(GLIDE_IS_TEXT_PROVIDER(self), NULL);
+  return GLIDE_TEXT_PROVIDER_GET_IFACE(self)->get_text(self, start, end);
+}
+
+#endif /* TEXT_PROVIDER_H */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -19,8 +19,8 @@ swank_process_test: swank_process_test.c swank_process.c real_swank_process.c pr
 swank_session_test: swank_session_test.c swank_session.c swank_process.c real_swank_session.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
-lisp_parser_test: lisp_parser_test.c ../64k/lisp-parser.c
-	$(CC) $(CFLAGS) `pkg-config --cflags gtk+-3.0 gtksourceview-4` $^ -o $@ $(LDLIBS) `pkg-config --libs gtk+-3.0 gtksourceview-4`
+lisp_parser_test: lisp_parser_test.c ../64k/lisp_parser.c ../64k/string_text_provider.c ../64k/text_provider.c
+	$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 run: all
 	./preferences_test

--- a/tests/lisp_parser_test.c
+++ b/tests/lisp_parser_test.c
@@ -1,15 +1,13 @@
-#include "lisp-parser.h"
+#include "lisp_parser.h"
+#include "string_text_provider.h"
 #include <glib.h>
-#include <gtk/gtk.h>
-#include <gtksourceview/gtksource.h>
 
 static LispParser *parser_from_text(const gchar *text)
 {
-  GtkSourceBuffer *buffer = gtk_source_buffer_new(NULL);
-  gtk_text_buffer_set_text(GTK_TEXT_BUFFER(buffer), text, -1);
-  LispParser *parser = lisp_parser_new(buffer);
+  TextProvider *provider = string_text_provider_new(text);
+  LispParser *parser = lisp_parser_new(provider);
   lisp_parser_parse(parser);
-  g_object_unref(buffer);
+  g_object_unref(provider);
   return parser;
 }
 
@@ -152,7 +150,6 @@ static void test_comment(void)
 int main(int argc, char *argv[])
 {
   g_test_init(&argc, &argv, NULL);
-  gtk_init_check(&argc, &argv);
   g_test_add_func("/lisp_parser/empty_file", test_empty_file);
   g_test_add_func("/lisp_parser/atom_symbol", test_atom_symbol);
   g_test_add_func("/lisp_parser/atom_string", test_atom_string);


### PR DESCRIPTION
## Summary
- refactor 64k LispParser to use TextProvider interface
- add Gtk and string implementations of TextProvider
- adjust parser views and source view to use new provider
- update tests for the new interface

## Testing
- `make -C tests`
- `tests/lisp_parser_test`

------
https://chatgpt.com/codex/tasks/task_e_68760c20d6c08328be662c076a635549